### PR TITLE
refactor: centralize stock history loading

### DIFF
--- a/src/stock_indicator/utils.py
+++ b/src/stock_indicator/utils.py
@@ -1,6 +1,36 @@
 """Utility helpers for the stock_indicator package."""
 
+import datetime
 from typing import Sequence
+
+import pandas as pd
+import yfinance as yf
+
+
+def load_stock_history(symbol: str, interval: str, decimals: int = 3) -> pd.DataFrame:
+    """Download historical stock data and normalize column values.
+
+    Args:
+        symbol: Ticker symbol to fetch.
+        interval: Data interval accepted by :func:`yfinance.download`.
+        decimals: Number of decimal places to round OHLC values.
+
+    Returns:
+        DataFrame with the stock history. The index is reset to expose a
+        ``Date`` column and OHLC values are rounded to the specified
+        precision. If no data is returned, the empty DataFrame is
+        returned unchanged.
+    """
+
+    end_date = datetime.date.today()
+    start_date = end_date - datetime.timedelta(days=365 * 100)
+    df_stock = yf.download(symbol, start=start_date, end=end_date, interval=interval)
+    if df_stock.empty:
+        return df_stock
+
+    df_stock = df_stock.round({"Low": decimals, "High": decimals, "Close": decimals, "Open": decimals})
+    df_stock.reset_index(inplace=True)
+    return df_stock
 
 
 def validate_series(series: Sequence[float], min_length: int = 1) -> None:

--- a/tests/test_pbb_helpers.py
+++ b/tests/test_pbb_helpers.py
@@ -1,9 +1,9 @@
 import pandas as pd
 import numpy as np
-from stock_indicator import indicators
+from stock_indicator import indicators, utils
 
 
-def test_get_stock_data(monkeypatch):
+def test_load_stock_history(monkeypatch):
     sample = pd.DataFrame(
         {
             "Open": [1.0, 2.0],
@@ -19,8 +19,8 @@ def test_get_stock_data(monkeypatch):
     def fake_download(symbol, start, end, interval):
         return sample
 
-    monkeypatch.setattr(indicators.yf, "download", fake_download)
-    df = indicators._get_stock_data("TEST", "1d")
+    monkeypatch.setattr(utils.yf, "download", fake_download)
+    df = utils.load_stock_history("TEST", "1d")
     assert list(df.columns) == ["Date", "Open", "High", "Low", "Close", "Adj Close", "Volume"]
     assert df["Close"].iloc[0] == 1.0
     assert df.index.tolist() == [0, 1]


### PR DESCRIPTION
## Summary
- add `load_stock_history` utility to wrap yfinance downloads and rounding
- update pbb, ftd, K1, and buyRating indicators to use the new helper
- adjust tests to verify `load_stock_history`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68924a06e62c832bb348a5385dc2df60