### PR TITLE
Remove unused imports from screen manager

### DIFF
--- a/screen_manager.py
+++ b/screen_manager.py
@@ -1,6 +1,4 @@
-import yfinance as yf
 import pandas as pd
-import numpy as np
 import time
 import datetime
 import logging


### PR DESCRIPTION
## Summary
- Remove unused `yfinance` and `numpy` imports from `screen_manager.py`.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_689255de9380832b8c3706d041126328