### PR TITLE
Clone symbols repo if missing

### DIFF
--- a/screen_manager.py
+++ b/screen_manager.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import sys
 from pathlib import Path
+import subprocess
 
 sys.path.append(str(Path(__file__).resolve().parent / "src"))
 from stock_indicator import indicators
@@ -45,6 +46,18 @@ def screen(parameter, debug_parameter, symbols_dir: Path | str = Path("US-Stock-
     start_time = time.time()
 
     symbols_dir = Path(symbols_dir)
+    if not symbols_dir.exists():
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "https://github.com/rreichel3/US-Stock-Symbols.git",
+                str(symbols_dir),
+            ],
+            check=True,
+        )
+        if not symbols_dir.exists():
+            raise FileNotFoundError(f"Failed to clone repository into {symbols_dir}")
 
     # Read JSON files
     amex_df = pd.read_json(symbols_dir / "amex" / "amex_tickers.json")


### PR DESCRIPTION
## Summary
- Import `subprocess` in `screen_manager.py`
- Clone `US-Stock-Symbols` repository automatically if the target directory is absent

## Testing
- `pytest` *(fails: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68925dbc4004832b829b5e90d19d56f9