### PR TITLE
Ensure scalar threshold comparisons in FTD indicator

### DIFF
--- a/src/stock_indicator/indicators.py
+++ b/src/stock_indicator/indicators.py
@@ -226,10 +226,14 @@ def ftd(
 		signal was found, and ``rating`` is the computed buy rating.
 
 	Side Effects:
-	- Downloads data via :func:`load_stock_history`.
-	- Prints progress and execution time to stdout.
-	"""
-	df_stock = load_stock_history(symbol, INTERVAL)
+        - Downloads data via :func:`load_stock_history`.
+        - Prints progress and execution time to stdout.
+        """
+        # Ensure numeric comparisons operate on plain floats
+        price_above = float(price_above)
+        volumn_above = float(volumn_above)
+
+        df_stock = load_stock_history(symbol, INTERVAL)
 
 	if df_stock.empty:
 		return False, 0.0


### PR DESCRIPTION
## Summary
- Cast `price_above` and `volumn_above` to floats at the start of `ftd` to ensure scalar comparisons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_689266c96ee8832b9af76c2bc258cb55