### PR TITLE
Add historical data downloader with retries

### DIFF
--- a/src/stock_indicator/data_loader.py
+++ b/src/stock_indicator/data_loader.py
@@ -1,0 +1,61 @@
+"""Functions for downloading historical stock market data."""
+# TODO: review
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pandas
+import yfinance
+
+LOGGER = logging.getLogger(__name__)
+
+
+def download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
+    """Download historical price data for a stock symbol.
+
+    Parameters
+    ----------
+    symbol: str
+        Stock ticker symbol to download.
+    start: str
+        Start date in ISO format (``YYYY-MM-DD``).
+    end: str
+        End date in ISO format (``YYYY-MM-DD``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Data frame containing the historical data.
+
+    Raises
+    ------
+    Exception
+        Propagates the last error if downloading repeatedly fails.
+    """
+    maximum_attempts = 3
+    for attempt_number in range(1, maximum_attempts + 1):
+        try:
+            downloaded_frame = yfinance.download(
+                symbol,
+                start=start,
+                end=end,
+                progress=False,
+            )
+            return downloaded_frame
+        except Exception as download_error:  # noqa: BLE001
+            LOGGER.warning(
+                "Attempt %d to download data for %s failed: %s",
+                attempt_number,
+                symbol,
+                download_error,
+            )
+            if attempt_number == maximum_attempts:
+                LOGGER.error(
+                    "Failed to download data for %s after %d attempts",
+                    symbol,
+                    maximum_attempts,
+                )
+                raise
+            time.sleep(1)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,89 @@
+"""Tests for the download_history utility."""
+# TODO: review
+
+import logging
+import os
+import sys
+import types
+
+import pandas
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+# Create a minimal yfinance stub before importing the module under test
+fake_yfinance_module = types.ModuleType("yfinance")
+fake_yfinance_module.download = lambda *args, **kwargs: pandas.DataFrame()
+sys.modules["yfinance"] = fake_yfinance_module
+
+from stock_indicator.data_loader import download_history
+
+
+def test_download_history_returns_dataframe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The function should return data provided by yfinance."""
+    expected_dataframe = pandas.DataFrame({"Close": [1.0, 2.0]})
+
+    def stubbed_download(
+        symbol: str,
+        start: str,
+        end: str,
+        progress: bool = False,
+    ) -> pandas.DataFrame:
+        return expected_dataframe
+
+    monkeypatch.setattr(
+        "stock_indicator.data_loader.yfinance.download", stubbed_download
+    )
+    result_dataframe = download_history("TEST", "2021-01-01", "2021-01-02")
+    pandas.testing.assert_frame_equal(result_dataframe, expected_dataframe)
+
+
+def test_download_history_retries_on_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The function should retry and log warnings on temporary failures."""
+    call_counter = {"count": 0}
+    expected_dataframe = pandas.DataFrame({"Close": [1.0]})
+
+    def flaky_download(
+        symbol: str,
+        start: str,
+        end: str,
+        progress: bool = False,
+    ) -> pandas.DataFrame:
+        call_counter["count"] += 1
+        if call_counter["count"] < 3:
+            raise ValueError("temporary error")
+        return expected_dataframe
+
+    monkeypatch.setattr(
+        "stock_indicator.data_loader.yfinance.download", flaky_download
+    )
+    with caplog.at_level(logging.WARNING):
+        result_dataframe = download_history("TEST", "2021-01-01", "2021-01-02")
+
+    assert call_counter["count"] == 3
+    pandas.testing.assert_frame_equal(result_dataframe, expected_dataframe)
+    assert "Attempt 1 to download data for TEST failed" in caplog.text
+
+
+def test_download_history_raises_after_max_attempts(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The function should raise the last error after exhausting retries."""
+
+    def failing_download(
+        symbol: str,
+        start: str,
+        end: str,
+        progress: bool = False,
+    ) -> pandas.DataFrame:
+        raise ValueError("permanent error")
+
+    monkeypatch.setattr(
+        "stock_indicator.data_loader.yfinance.download", failing_download
+    )
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError):
+            download_history("TEST", "2021-01-01", "2021-01-02")
+    assert "Failed to download data for TEST after" in caplog.text


### PR DESCRIPTION
## Summary
- add `download_history` utility using yfinance with retry and logging
- cover download logic with unit tests including retry behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68a3661e95e8832b8e330002ed8a635a