### PR TITLE
Add US stock symbols fetcher with caching

### DIFF
--- a/src/stock_indicator/symbols.py
+++ b/src/stock_indicator/symbols.py
@@ -1,0 +1,46 @@
+"""Utility functions for retrieving stock symbols."""
+# TODO: review
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import requests
+
+SYMBOLS_URL = (
+    "https://raw.githubusercontent.com/datasets/"
+    "us-stock-symbols/master/data/nyse-listed.csv"
+)
+SYMBOLS_CACHE_PATH = Path(__file__).with_name("us_symbols.json")
+
+
+def fetch_us_symbols() -> list[str]:
+    """Fetch a list of U.S. stock ticker symbols.
+
+    The function downloads symbol data from a public GitHub dataset and caches
+    it locally to avoid repeated network requests.
+
+    Returns
+    -------
+    list[str]
+        List of stock ticker symbols.
+
+    Raises
+    ------
+    requests.RequestException
+        If the remote request fails.
+    """
+    if SYMBOLS_CACHE_PATH.exists():
+        with SYMBOLS_CACHE_PATH.open("r", encoding="utf-8") as cache_file:
+            return json.load(cache_file)
+
+    response = requests.get(SYMBOLS_URL, timeout=30)
+    response.raise_for_status()
+    csv_text = response.text
+    csv_reader = csv.DictReader(csv_text.splitlines())
+    symbol_list = [row["Symbol"].strip() for row in csv_reader if row.get("Symbol")]
+    with SYMBOLS_CACHE_PATH.open("w", encoding="utf-8") as cache_file:
+        json.dump(symbol_list, cache_file)
+    return symbol_list

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1,0 +1,40 @@
+"""Tests for the fetch_us_symbols utility."""
+# TODO: review
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from stock_indicator.symbols import fetch_us_symbols
+
+
+def test_fetch_us_symbols_parses_symbols(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The function should return a list of symbols parsed from CSV data."""
+    csv_text = "Symbol,Name\nAAPL,Apple Inc.\nMSFT,Microsoft Corp."
+
+    class DummyResponse:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def fake_get(url: str, timeout: int) -> DummyResponse:
+        return DummyResponse(csv_text)
+
+    monkeypatch.setattr("stock_indicator.symbols.requests.get", fake_get)
+    cache_path = tmp_path / "symbols.json"
+    monkeypatch.setattr("stock_indicator.symbols.SYMBOLS_CACHE_PATH", cache_path)
+
+    symbol_list = fetch_us_symbols()
+    assert "AAPL" in symbol_list
+    assert "MSFT" in symbol_list
+    assert cache_path.exists()
+    with cache_path.open("r", encoding="utf-8") as cache_file:
+        cached_list = json.load(cache_file)
+    assert cached_list == symbol_list


### PR DESCRIPTION
## Summary
- implement `fetch_us_symbols` to download and cache U.S. ticker symbols from a GitHub dataset
- add unit test ensuring symbols are parsed and cached correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68a3acfc3eac832b85069e70a2a3dede