### PR TITLE
Add command-line interface for stock simulations

### DIFF
--- a/src/stock_indicator/cli.py
+++ b/src/stock_indicator/cli.py
@@ -1,0 +1,100 @@
+"""Command line interface for running stock simulations."""
+# TODO: review
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import List, Optional
+
+import pandas
+
+from . import data_loader, indicators, simulator, symbols
+
+LOGGER = logging.getLogger(__name__)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the command line interface."""
+    parser = argparse.ArgumentParser(
+        description="Run indicator calculations and trade simulations."
+    )
+    parser.add_argument("--symbol", required=True, help="Stock ticker symbol to use.")
+    parser.add_argument(
+        "--start", required=True, help="Start date for the historical data (YYYY-MM-DD)."
+    )
+    parser.add_argument(
+        "--end", required=True, help="End date for the historical data (YYYY-MM-DD)."
+    )
+    parser.add_argument(
+        "--strategy",
+        required=True,
+        choices=["sma"],
+        help="Trading strategy to apply to the data.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional path to a CSV file for writing the trade results.",
+    )
+    return parser
+
+
+def run_cli(argument_list: Optional[List[str]] = None) -> None:
+    """Parse command line arguments and execute the selected strategy."""
+    parser = create_parser()
+    parsed_arguments = parser.parse_args(argument_list)
+
+    try:
+        available_symbol_list = symbols.fetch_us_symbols()
+        if (
+            available_symbol_list
+            and parsed_arguments.symbol not in available_symbol_list
+        ):
+            raise ValueError(f"Unknown symbol: {parsed_arguments.symbol}")
+    except Exception as symbol_error:  # noqa: BLE001
+        LOGGER.warning("Could not verify symbol: %s", symbol_error)
+
+    price_data_frame = data_loader.download_history(
+        parsed_arguments.symbol, parsed_arguments.start, parsed_arguments.end
+    ).rename(columns=str.lower)
+
+    if parsed_arguments.strategy == "sma":
+        price_data_frame["indicator"] = indicators.sma(
+            price_data_frame["close"], window_size=20
+        )
+
+        def entry_rule(current_row: pandas.Series) -> bool:
+            indicator_value = current_row["indicator"]
+            return current_row["close"] > indicator_value
+
+        def exit_rule(
+            current_row: pandas.Series, entry_row: pandas.Series
+        ) -> bool:
+            indicator_value = current_row["indicator"]
+            return current_row["close"] < indicator_value
+
+    else:
+        raise ValueError(f"Unsupported strategy: {parsed_arguments.strategy}")
+
+    simulation_result = simulator.simulate_trades(
+        price_data_frame, entry_rule, exit_rule
+    )
+    LOGGER.info("Total profit: %s", simulation_result.total_profit)
+    if parsed_arguments.output:
+        trade_record_list = [
+            {
+                "entry_index": trade.entry_index,
+                "exit_index": trade.exit_index,
+                "entry_price": trade.entry_price,
+                "exit_price": trade.exit_price,
+                "profit": trade.profit,
+            }
+            for trade in simulation_result.trades
+        ]
+        result_data_frame = pandas.DataFrame(trade_record_list)
+        result_data_frame.to_csv(parsed_arguments.output, index=False)
+        LOGGER.info("Results written to %s", parsed_arguments.output)
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,80 @@
+# TODO: review
+
+import logging
+import os
+import sys
+from typing import Callable
+
+import pandas
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from stock_indicator import cli
+from stock_indicator.simulator import SimulationResult
+
+
+def test_parser_handles_arguments() -> None:
+    """The parser should correctly read required arguments."""
+    parser = cli.create_parser()
+    parsed_arguments = parser.parse_args(
+        [
+            "--symbol",
+            "AAA",
+            "--start",
+            "2022-01-01",
+            "--end",
+            "2022-02-01",
+            "--strategy",
+            "sma",
+        ]
+    )
+    assert parsed_arguments.symbol == "AAA"
+    assert parsed_arguments.start == "2022-01-01"
+    assert parsed_arguments.end == "2022-02-01"
+    assert parsed_arguments.strategy == "sma"
+
+
+def test_run_cli_invokes_components(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The CLI should call underlying modules and log the result."""
+
+    def fake_fetch_us_symbols() -> list[str]:
+        return ["AAA"]
+
+    def fake_download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
+        assert symbol == "AAA"
+        assert start == "2022-01-01"
+        assert end == "2022-02-01"
+        return pandas.DataFrame({"close": [1.0, 2.0, 3.0]})
+
+    def fake_sma(price_series: pandas.Series, window_size: int) -> pandas.Series:
+        return pandas.Series([1.0, 1.5, 2.0])
+
+    def fake_simulate_trades(
+        data_frame: pandas.DataFrame,
+        entry_rule: Callable[[pandas.Series], bool],
+        exit_rule: Callable[[pandas.Series, pandas.Series], bool],
+    ) -> SimulationResult:
+        return SimulationResult(trades=[], total_profit=5.0)
+
+    monkeypatch.setattr(cli.symbols, "fetch_us_symbols", fake_fetch_us_symbols)
+    monkeypatch.setattr(cli.data_loader, "download_history", fake_download_history)
+    monkeypatch.setattr(cli.indicators, "sma", fake_sma)
+    monkeypatch.setattr(cli.simulator, "simulate_trades", fake_simulate_trades)
+
+    with caplog.at_level(logging.INFO):
+        cli.run_cli(
+            [
+                "--symbol",
+                "AAA",
+                "--start",
+                "2022-01-01",
+                "--end",
+                "2022-02-01",
+                "--strategy",
+                "sma",
+            ]
+        )
+    assert "Total profit: 5.0" in caplog.text


### PR DESCRIPTION
## Summary
- add argparse-driven CLI to run indicator calculations and trade simulations
- integrate symbol lookup, data loading, indicator calculation and simulation with optional CSV output
- test CLI argument parsing and integration with underlying modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy requests -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68a3af96f608832bb2fbbd285d42e61f