### PR TITLE
Ensure indicator comparison uses label-aligned values

### DIFF
--- a/src/stock_indicator/cli.py
+++ b/src/stock_indicator/cli.py
@@ -59,19 +59,24 @@ def run_cli(argument_list: Optional[List[str]] = None) -> None:
     ).rename(columns=str.lower)
 
     if parsed_arguments.strategy == "sma":
-        price_data_frame["indicator"] = indicators.sma(
+        indicator_series = indicators.sma(
             price_data_frame["close"], window_size=20
         )
+        price_data_frame["indicator"] = indicator_series
 
         def entry_rule(current_row: pandas.Series) -> bool:
-            indicator_value = current_row["indicator"]
-            return current_row["close"] > indicator_value
+            """Determine whether to open a trade for the given row."""
+            row_label = current_row.name
+            indicator_at_label = indicator_series.loc[row_label]
+            return current_row["close"] > indicator_at_label
 
         def exit_rule(
             current_row: pandas.Series, entry_row: pandas.Series
         ) -> bool:
-            indicator_value = current_row["indicator"]
-            return current_row["close"] < indicator_value
+            """Determine whether to close the current trade."""
+            row_label = current_row.name
+            indicator_at_label = indicator_series.loc[row_label]
+            return current_row["close"] < indicator_at_label
 
     else:
         raise ValueError(f"Unsupported strategy: {parsed_arguments.strategy}")

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -6,6 +6,8 @@ import sys
 
 import pandas
 
+from stock_indicator.indicators import sma
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from stock_indicator.simulator import SimulationResult, simulate_trades
@@ -31,3 +33,45 @@ def test_simulate_trades_executes_trade_flow() -> None:
     assert completed_trade.exit_price == 106.0
     assert completed_trade.profit == 4.0
     assert result.total_profit == 4.0
+
+
+def test_simulate_trades_with_sma_strategy_uses_aligned_labels() -> None:
+    """Verify SMA-based rules use matching index labels during comparison."""
+    price_data_frame = pandas.DataFrame(
+        {"close": [100.0, 102.0, 104.0, 103.0, 106.0]},
+        index=[10, 11, 12, 13, 14],
+    )
+    simple_moving_average_series = sma(
+        price_data_frame["close"], window_size=2
+    )
+    simple_moving_average_series = simple_moving_average_series.iloc[::-1]
+
+    def entry_rule(current_row: pandas.Series) -> bool:
+        """Determine when to enter a trade based on SMA."""
+        row_label = current_row.name
+        indicator_at_label = simple_moving_average_series.loc[row_label]
+        if pandas.isna(indicator_at_label):
+            return False
+        return current_row["close"] > indicator_at_label
+
+    def exit_rule(
+        current_row: pandas.Series, entry_row: pandas.Series
+    ) -> bool:
+        """Determine when to exit a trade based on SMA."""
+        row_label = current_row.name
+        indicator_at_label = simple_moving_average_series.loc[row_label]
+        if pandas.isna(indicator_at_label):
+            return False
+        return current_row["close"] < indicator_at_label
+
+    result = simulate_trades(price_data_frame, entry_rule, exit_rule)
+
+    assert isinstance(result, SimulationResult)
+    assert len(result.trades) == 1
+    completed_trade = result.trades[0]
+    assert completed_trade.entry_index == 1
+    assert completed_trade.exit_index == 3
+    assert completed_trade.entry_price == 102.0
+    assert completed_trade.exit_price == 103.0
+    assert completed_trade.profit == 1.0
+    assert result.total_profit == 1.0


### PR DESCRIPTION
## Summary
- Align SMA indicator lookup by DataFrame index labels in CLI strategy rules
- Add simulator test validating SMA strategy uses label-aligned indicator values

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy requests` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68a3ecd915e8832ba65bc5022fef0239