### PR TITLE
Use local symbol cache for validation

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,1 @@
+symbols.csv

--- a/src/stock_indicator/cli.py
+++ b/src/stock_indicator/cli.py
@@ -45,7 +45,7 @@ def run_cli(argument_list: Optional[List[str]] = None) -> None:
     parsed_arguments = parser.parse_args(argument_list)
 
     try:
-        available_symbol_list = symbols.fetch_us_symbols()
+        available_symbol_list = symbols.load_symbols()
         if (
             available_symbol_list
             and parsed_arguments.symbol not in available_symbol_list

--- a/src/stock_indicator/data_loader.py
+++ b/src/stock_indicator/data_loader.py
@@ -8,6 +8,7 @@ import time
 
 import pandas
 import yfinance
+from .symbols import load_symbols
 
 LOGGER = logging.getLogger(__name__)
 
@@ -31,9 +32,15 @@ def download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
 
     Raises
     ------
+    ValueError
+        If the provided symbol is not known.
     Exception
         Propagates the last error if downloading repeatedly fails.
     """
+    available_symbol_list = load_symbols()
+    if available_symbol_list and symbol not in available_symbol_list:
+        raise ValueError(f"Unknown symbol: {symbol}")
+
     maximum_attempts = 3
     for attempt_number in range(1, maximum_attempts + 1):
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ def test_run_cli_invokes_components(
 ) -> None:
     """The CLI should call underlying modules and log the result."""
 
-    def fake_fetch_us_symbols() -> list[str]:
+    def fake_load_symbols() -> list[str]:
         return ["AAA"]
 
     def fake_download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
@@ -59,7 +59,7 @@ def test_run_cli_invokes_components(
     ) -> SimulationResult:
         return SimulationResult(trades=[], total_profit=5.0)
 
-    monkeypatch.setattr(cli.symbols, "fetch_us_symbols", fake_fetch_us_symbols)
+    monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)
     monkeypatch.setattr(cli.data_loader, "download_history", fake_download_history)
     monkeypatch.setattr(cli.indicators, "sma", fake_sma)
     monkeypatch.setattr(cli.simulator, "simulate_trades", fake_simulate_trades)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -34,6 +34,7 @@ def test_download_history_returns_dataframe(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(
         "stock_indicator.data_loader.yfinance.download", stubbed_download
     )
+    monkeypatch.setattr("stock_indicator.data_loader.load_symbols", lambda: ["TEST"])
     result_dataframe = download_history("TEST", "2021-01-01", "2021-01-02")
     pandas.testing.assert_frame_equal(result_dataframe, expected_dataframe)
 
@@ -59,6 +60,7 @@ def test_download_history_retries_on_failure(
     monkeypatch.setattr(
         "stock_indicator.data_loader.yfinance.download", flaky_download
     )
+    monkeypatch.setattr("stock_indicator.data_loader.load_symbols", lambda: ["TEST"])
     with caplog.at_level(logging.WARNING):
         result_dataframe = download_history("TEST", "2021-01-01", "2021-01-02")
 
@@ -83,6 +85,7 @@ def test_download_history_raises_after_max_attempts(
     monkeypatch.setattr(
         "stock_indicator.data_loader.yfinance.download", failing_download
     )
+    monkeypatch.setattr("stock_indicator.data_loader.load_symbols", lambda: ["TEST"])
     with caplog.at_level(logging.ERROR):
         with pytest.raises(ValueError):
             download_history("TEST", "2021-01-01", "2021-01-02")


### PR DESCRIPTION
## Summary
- add utilities to download and cache stock symbols locally
- validate symbols with the cache in CLI and data loader
- update tests for new symbol cache behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68a3eccd4188832b8409a84078a7cefe