### PR TITLE
Switch symbol source to plain text URL

### DIFF
--- a/src/stock_indicator/symbols.py
+++ b/src/stock_indicator/symbols.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import csv
 import logging
 from pathlib import Path
 
@@ -11,17 +10,18 @@ import requests
 
 LOGGER = logging.getLogger(__name__)
 
-SYMBOL_SOURCE_URL = (
-    "https://raw.githubusercontent.com/rreichel3/US-Stock-Symbols/main/all/all_stocks.csv"
+# Raw text file with one ticker symbol per line.
+SYMBOL_SOURCE_TEXT_URL = (
+    "https://raw.githubusercontent.com/rreichel3/US-Stock-Symbols/main/all/all_tickers.txt"
 )
 SYMBOL_CACHE_PATH = (
-    Path(__file__).resolve().parent.parent.parent / "data" / "symbols.csv"
+    Path(__file__).resolve().parent.parent.parent / "data" / "symbols.txt"
 )
 
 
 def update_symbol_cache() -> None:
     """Download the latest symbol list and store it locally."""
-    response = requests.get(SYMBOL_SOURCE_URL, timeout=30)
+    response = requests.get(SYMBOL_SOURCE_TEXT_URL, timeout=30)
     response.raise_for_status()
     SYMBOL_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
     SYMBOL_CACHE_PATH.write_text(response.text, encoding="utf-8")
@@ -29,15 +29,17 @@ def update_symbol_cache() -> None:
 
 
 def load_symbols() -> list[str]:
-    """Return the list of symbols from the local cache."""
+    """Return the list of symbols from the local cache.
+
+    The cache file contains one ticker symbol per line.
+    """
     if not SYMBOL_CACHE_PATH.exists():
         update_symbol_cache()
     with SYMBOL_CACHE_PATH.open("r", encoding="utf-8") as symbol_file:
-        reader = csv.DictReader(symbol_file)
         symbol_list: list[str] = []
-        for row in reader:
-            symbol_value = row.get("Symbol") or row.get("symbol")
-            if symbol_value:
-                symbol_list.append(symbol_value.strip())
+        for symbol_line in symbol_file:
+            stripped_symbol = symbol_line.strip()
+            if stripped_symbol:
+                symbol_list.append(stripped_symbol)
     return symbol_list
 

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -15,7 +15,7 @@ from stock_indicator.symbols import load_symbols
 def test_load_symbols_fetches_and_reads(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The loader should retrieve symbols and cache them locally."""
 
-    csv_text = "Symbol,Name\nAAA,Alpha Inc.\nBBB,Beta LLC"
+    symbol_text = "AAA\nBBB"
 
     class DummyResponse:
         def __init__(self, text: str) -> None:
@@ -25,10 +25,10 @@ def test_load_symbols_fetches_and_reads(monkeypatch: pytest.MonkeyPatch, tmp_pat
             return None
 
     def fake_get(request_url: str, request_timeout: int) -> DummyResponse:  # noqa: ARG001
-        return DummyResponse(csv_text)
+        return DummyResponse(symbol_text)
 
     monkeypatch.setattr("stock_indicator.symbols.requests.get", fake_get)
-    cache_path = tmp_path / "symbols.csv"
+    cache_path = tmp_path / "symbols.txt"
     monkeypatch.setattr("stock_indicator.symbols.SYMBOL_CACHE_PATH", cache_path)
 
     symbol_list = load_symbols()


### PR DESCRIPTION
## Summary
- replace symbol source with plain text ticker list
- adjust cache path and loader to handle line-separated symbols
- update unit test for new symbol source format

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68a43053a8dc832b80970cc40f2dc6a7