### PR TITLE
feat: parse symbol cache formats

### DIFF
--- a/src/stock_indicator/symbols.py
+++ b/src/stock_indicator/symbols.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 
@@ -20,7 +21,12 @@ SYMBOL_CACHE_PATH = (
 
 
 def update_symbol_cache() -> None:
-    """Download the latest symbol list and store it locally."""
+    """Download the latest symbol list and store it locally.
+
+    The remote endpoint may return either a newline separated text file or a JSON
+    encoded list of ticker symbols. The content is saved verbatim and parsed when
+    loaded.
+    """
     response = requests.get(SYMBOL_SOURCE_TEXT_URL, timeout=30)
     response.raise_for_status()
     SYMBOL_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -31,15 +37,25 @@ def update_symbol_cache() -> None:
 def load_symbols() -> list[str]:
     """Return the list of symbols from the local cache.
 
-    The cache file contains one ticker symbol per line.
+    The cache file may contain one ticker per line or a JSON encoded list of
+    strings representing ticker symbols.
     """
     if not SYMBOL_CACHE_PATH.exists():
         update_symbol_cache()
-    with SYMBOL_CACHE_PATH.open("r", encoding="utf-8") as symbol_file:
-        symbol_list: list[str] = []
-        for symbol_line in symbol_file:
-            stripped_symbol = symbol_line.strip()
-            if stripped_symbol:
-                symbol_list.append(stripped_symbol)
+    file_content = SYMBOL_CACHE_PATH.read_text(encoding="utf-8")
+    try:
+        parsed_symbols = json.loads(file_content)
+    except json.JSONDecodeError:
+        symbol_list = [
+            line.strip()
+            for line in file_content.splitlines()
+            if line.strip()
+        ]
+    else:
+        if not isinstance(parsed_symbols, list) or not all(
+            isinstance(symbol, str) for symbol in parsed_symbols
+        ):
+            raise ValueError("Symbol cache JSON must be a list of strings.")
+        symbol_list = parsed_symbols
     return symbol_list
 

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1,6 +1,7 @@
 """Tests for symbol cache utilities."""
 # TODO: review
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -34,4 +35,28 @@ def test_load_symbols_fetches_and_reads(monkeypatch: pytest.MonkeyPatch, tmp_pat
     symbol_list = load_symbols()
     assert "AAA" in symbol_list
     assert "BBB" in symbol_list
+    assert cache_path.exists()
+
+
+def test_load_symbols_reads_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The loader should handle a JSON list of symbols."""
+
+    symbol_sequence = ["AAA", "BBB"]
+
+    class DummyResponse:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def fake_get(request_url: str, request_timeout: int) -> DummyResponse:  # noqa: ARG001
+        return DummyResponse(json.dumps(symbol_sequence))
+
+    monkeypatch.setattr("stock_indicator.symbols.requests.get", fake_get)
+    cache_path = tmp_path / "symbols.txt"
+    monkeypatch.setattr("stock_indicator.symbols.SYMBOL_CACHE_PATH", cache_path)
+
+    symbol_list = load_symbols()
+    assert symbol_list == symbol_sequence
     assert cache_path.exists()


### PR DESCRIPTION
## Summary
- handle symbol cache as text or JSON
- test JSON symbol loading

## Testing
- `python -m py_compile src/stock_indicator/symbols.py tests/test_symbols.py`
- `pytest` *(fails: No module named 'requests', 'pandas', etc.)*
- `pip install pandas yfinance requests` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68a4323413c0832b88b0a81f10d30826