### PR TITLE
Add interactive management shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ python -m stock_indicator.cli --symbol AAPL --start 2023-01-01 --end 2023-06-01 
 * `--strategy` — indicator or strategy to apply, such as `sma` for simple moving average.
 * `--output` — file path for saving generated trades as a CSV file.
 
+### Management Shell
+
+The package provides an interactive shell for updating the symbol cache and
+downloading historical price data.
+
+```bash
+python -m stock_indicator.manage
+
+(stock-indicator) update_symbols
+(stock-indicator) update_data AAPL 2024-01-01 2024-02-01
+(stock-indicator) update_all_data 2024-01-01 2024-02-01
+(stock-indicator) exit
+```
+
+* `update_symbols` downloads the latest list of available ticker symbols.
+* `update_data SYMBOL START END` saves historical data for the given symbol to
+  `data/<SYMBOL>.csv`.
+* `update_all_data START END` performs the download for every cached symbol.
+
 ## Contribution Guidelines
 1. Fork the repository and create a new branch for each feature or bug fix.
 2. Ensure your code passes all tests by running `pytest` before submitting.

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1,0 +1,71 @@
+"""Interactive shell for managing symbol cache and historical data."""
+
+# TODO: review
+
+from __future__ import annotations
+
+import cmd
+import logging
+from pathlib import Path
+from typing import List
+
+from pandas import DataFrame
+
+from . import data_loader, symbols
+
+LOGGER = logging.getLogger(__name__)
+
+DATA_DIRECTORY = Path(__file__).resolve().parent.parent.parent / "data"
+
+
+class StockShell(cmd.Cmd):
+    """Interactive command shell for stock data maintenance."""
+
+    intro = "Stock Indicator shell. Type help or ? to list commands."
+    prompt = "(stock-indicator) "
+
+    def do_update_symbols(self, argument_line: str) -> None:  # noqa: D401
+        """update_symbols\n        Download the latest list of ticker symbols."""
+        symbols.update_symbol_cache()
+        self.stdout.write("Symbol cache updated\n")
+
+    def do_update_data(self, argument_line: str) -> None:  # noqa: D401
+        """update_data SYMBOL START END\n        Download data for SYMBOL between START and END and store as CSV."""
+        argument_parts: List[str] = argument_line.split()
+        if len(argument_parts) != 3:
+            self.stdout.write("usage: update_data SYMBOL START END\n")
+            return
+        symbol_name, start_date, end_date = argument_parts
+        data_frame: DataFrame = data_loader.download_history(
+            symbol_name, start_date, end_date
+        )
+        DATA_DIRECTORY.mkdir(parents=True, exist_ok=True)
+        output_path = DATA_DIRECTORY / f"{symbol_name}.csv"
+        data_frame.to_csv(output_path, index=False)
+        self.stdout.write(f"Data written to {output_path}\n")
+
+    def do_update_all_data(self, argument_line: str) -> None:  # noqa: D401
+        """update_all_data START END\n        Download data for all cached symbols."""
+        argument_parts: List[str] = argument_line.split()
+        if len(argument_parts) != 2:
+            self.stdout.write("usage: update_all_data START END\n")
+            return
+        start_date, end_date = argument_parts
+        symbol_list = symbols.load_symbols()
+        for symbol_name in symbol_list:
+            data_frame: DataFrame = data_loader.download_history(
+                symbol_name, start_date, end_date
+            )
+            DATA_DIRECTORY.mkdir(parents=True, exist_ok=True)
+            output_path = DATA_DIRECTORY / f"{symbol_name}.csv"
+            data_frame.to_csv(output_path, index=False)
+            self.stdout.write(f"Data written to {output_path}\n")
+
+    def do_exit(self, argument_line: str) -> bool:  # noqa: D401
+        """exit\n        Exit the shell."""
+        self.stdout.write("Bye\n")
+        return True
+
+
+if __name__ == "__main__":
+    StockShell().cmdloop()

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -1,0 +1,90 @@
+"""Tests for the interactive management shell."""
+
+# TODO: review
+
+import io
+import os
+import sys
+from pathlib import Path
+
+import pandas
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+
+def test_update_symbols(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The command should invoke the symbol cache update."""
+    import stock_indicator.manage as manage_module
+
+    call_record = {"called": False}
+
+    def fake_update_symbol_cache() -> None:
+        call_record["called"] = True
+
+    monkeypatch.setattr(
+        manage_module.symbols, "update_symbol_cache", fake_update_symbol_cache
+    )
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd("update_symbols")
+    assert call_record["called"] is True
+
+
+def test_update_data(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The command should download data and write it to a CSV file."""
+    import stock_indicator.manage as manage_module
+
+    recorded_arguments: dict[str, str] = {}
+
+    def fake_download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
+        recorded_arguments["symbol"] = symbol
+        recorded_arguments["start"] = start
+        recorded_arguments["end"] = end
+        return pandas.DataFrame({"close": [1.0]})
+
+    monkeypatch.setattr(
+        manage_module.data_loader, "download_history", fake_download_history
+    )
+    monkeypatch.setattr(manage_module, "DATA_DIRECTORY", tmp_path)
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd("update_data TEST 2023-01-01 2023-01-02")
+    output_file = tmp_path / "TEST.csv"
+    assert output_file.exists()
+    assert recorded_arguments == {
+        "symbol": "TEST",
+        "start": "2023-01-01",
+        "end": "2023-01-02",
+    }
+
+
+def test_update_all_data(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The command should download data for every symbol in the cache."""
+    import stock_indicator.manage as manage_module
+
+    symbol_list = ["AAA", "BBB"]
+
+    def fake_load_symbols() -> list[str]:
+        return symbol_list
+
+    download_calls: list[str] = []
+
+    def fake_download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
+        download_calls.append(symbol)
+        return pandas.DataFrame({"close": [1.0]})
+
+    monkeypatch.setattr(manage_module.symbols, "load_symbols", fake_load_symbols)
+    monkeypatch.setattr(
+        manage_module.data_loader, "download_history", fake_download_history
+    )
+    monkeypatch.setattr(manage_module, "DATA_DIRECTORY", tmp_path)
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd("update_all_data 2023-01-01 2023-01-02")
+
+    for symbol in symbol_list:
+        assert (tmp_path / f"{symbol}.csv").exists()
+    assert download_calls == symbol_list


### PR DESCRIPTION
## Summary
- add `manage.py` interactive shell for updating symbols and historical data
- document shell usage in README
- test shell commands for symbol and data updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68a455ba8f80832bb48f2364a31c0951