### PR TITLE
Record trade entry and exit dates

### DIFF
--- a/src/stock_indicator/cli.py
+++ b/src/stock_indicator/cli.py
@@ -88,8 +88,8 @@ def run_cli(argument_list: Optional[List[str]] = None) -> None:
     if parsed_arguments.output:
         trade_record_list = [
             {
-                "entry_index": trade.entry_index,
-                "exit_index": trade.exit_index,
+                "entry_date": trade.entry_date,
+                "exit_date": trade.exit_date,
                 "entry_price": trade.entry_price,
                 "exit_price": trade.exit_price,
                 "profit": trade.profit,

--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -13,8 +13,8 @@ import pandas
 class Trade:
     """Record details for a completed trade."""
 
-    entry_index: int
-    exit_index: int
+    entry_date: pandas.Timestamp
+    exit_date: pandas.Timestamp
     entry_price: float
     exit_price: float
     profit: float
@@ -53,16 +53,16 @@ def simulate_trades(
     trades: List[Trade] = []
     in_position = False
     entry_row: pandas.Series | None = None
-    entry_index: int | None = None
+    entry_row_index: int | None = None
     for row_index in range(len(data)):
         current_row = data.iloc[row_index]
         if not in_position:
             if entry_rule(current_row):
                 in_position = True
                 entry_row = current_row
-                entry_index = row_index
+                entry_row_index = row_index
         else:
-            if entry_row is None or entry_index is None:
+            if entry_row is None or entry_row_index is None:
                 continue
             if exit_rule(current_row, entry_row):
                 entry_price = float(entry_row["close"])
@@ -70,8 +70,8 @@ def simulate_trades(
                 profit_value = exit_price - entry_price
                 trades.append(
                     Trade(
-                        entry_index=entry_index,
-                        exit_index=row_index,
+                        entry_date=data.index[entry_row_index],
+                        exit_date=data.index[row_index],
                         entry_price=entry_price,
                         exit_price=exit_price,
                         profit=profit_value,
@@ -79,6 +79,6 @@ def simulate_trades(
                 )
                 in_position = False
                 entry_row = None
-                entry_index = None
+                entry_row_index = None
     total_profit = sum(completed_trade.profit for completed_trade in trades)
     return SimulationResult(trades=trades, total_profit=total_profit)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -27,8 +27,10 @@ def test_simulate_trades_executes_trade_flow() -> None:
     assert isinstance(result, SimulationResult)
     assert len(result.trades) == 1
     completed_trade = result.trades[0]
-    assert completed_trade.entry_index == 1
-    assert completed_trade.exit_index == 4
+    expected_entry_date = data.index[1]
+    expected_exit_date = data.index[4]
+    assert completed_trade.entry_date == expected_entry_date
+    assert completed_trade.exit_date == expected_exit_date
     assert completed_trade.entry_price == 102.0
     assert completed_trade.exit_price == 106.0
     assert completed_trade.profit == 4.0
@@ -69,8 +71,10 @@ def test_simulate_trades_with_sma_strategy_uses_aligned_labels() -> None:
     assert isinstance(result, SimulationResult)
     assert len(result.trades) == 1
     completed_trade = result.trades[0]
-    assert completed_trade.entry_index == 1
-    assert completed_trade.exit_index == 3
+    expected_entry_date = price_data_frame.index[1]
+    expected_exit_date = price_data_frame.index[3]
+    assert completed_trade.entry_date == expected_entry_date
+    assert completed_trade.exit_date == expected_exit_date
     assert completed_trade.entry_price == 102.0
     assert completed_trade.exit_price == 103.0
     assert completed_trade.profit == 1.0


### PR DESCRIPTION
## Summary
- track entry and exit dates for simulated trades
- output trade dates in CLI results
- adjust simulator tests for date-based trades

## Testing
- `pytest tests/test_simulator.py::test_simulate_trades_executes_trade_flow -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68a48c0b59b0832b866cc6524d6d4457