### PR TITLE
Allow optional download parameters

### DIFF
--- a/src/stock_indicator/data_loader.py
+++ b/src/stock_indicator/data_loader.py
@@ -5,15 +5,22 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Any
 
 import pandas
 import yfinance
+
 from .symbols import load_symbols
 
 LOGGER = logging.getLogger(__name__)
 
 
-def download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
+def download_history(
+    symbol: str,
+    start: str,
+    end: str,
+    **download_options: Any,
+) -> pandas.DataFrame:
     """Download historical price data for a stock symbol.
 
     Parameters
@@ -24,6 +31,9 @@ def download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
         Start date in ISO format (``YYYY-MM-DD``).
     end: str
         End date in ISO format (``YYYY-MM-DD``).
+    **download_options
+        Additional keyword arguments forwarded to :func:`yfinance.download`, such
+        as ``actions``, ``auto_adjust``, or ``interval``.
 
     Returns
     -------
@@ -49,6 +59,7 @@ def download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
                 start=start,
                 end=end,
                 progress=False,
+                **download_options,
             )
             return downloaded_frame
         except Exception as download_error:  # noqa: BLE001

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -90,3 +90,27 @@ def test_download_history_raises_after_max_attempts(
         with pytest.raises(ValueError):
             download_history("TEST", "2021-01-01", "2021-01-02")
     assert "Failed to download data for TEST after" in caplog.text
+
+
+def test_download_history_forwards_optional_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The function should forward optional keyword arguments to yfinance."""
+    captured_arguments: dict[str, str] = {}
+
+    def stubbed_download(
+        symbol: str,
+        start: str,
+        end: str,
+        progress: bool = False,
+        **options: str,
+    ) -> pandas.DataFrame:
+        captured_arguments.update(options)
+        return pandas.DataFrame()
+
+    monkeypatch.setattr(
+        "stock_indicator.data_loader.yfinance.download", stubbed_download
+    )
+    monkeypatch.setattr("stock_indicator.data_loader.load_symbols", lambda: ["TEST"])
+    download_history("TEST", "2021-01-01", "2021-01-02", interval="1h")
+    assert captured_arguments["interval"] == "1h"


### PR DESCRIPTION
## Summary
- forward optional keyword arguments from `download_history` to `yfinance.download`
- document new parameters and add test verifying pass-through

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy yfinance` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68a49fb2aa30832b8618aa2251b94b29