### PR TITLE
Include S&P 500 in data updates

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -16,6 +16,7 @@ from . import data_loader, symbols
 LOGGER = logging.getLogger(__name__)
 
 DATA_DIRECTORY = Path(__file__).resolve().parent.parent.parent / "data"
+SP500_SYMBOL = "^GSPC"  # TODO: review
 
 
 class StockShell(cmd.Cmd):
@@ -55,6 +56,8 @@ class StockShell(cmd.Cmd):
             return
         start_date, end_date = argument_parts
         symbol_list = symbols.load_symbols()
+        if SP500_SYMBOL not in symbol_list:
+            symbol_list.append(SP500_SYMBOL)
         for symbol_name in symbol_list:
             data_frame: DataFrame = data_loader.download_history(
                 symbol_name, start_date, end_date

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -88,12 +88,12 @@ def test_update_all_data(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
     )
     monkeypatch.setattr(manage_module, "DATA_DIRECTORY", tmp_path)
 
+    expected_symbols = symbol_list + [manage_module.SP500_SYMBOL]
     shell = manage_module.StockShell(stdout=io.StringIO())
     shell.onecmd("update_all_data 2023-01-01 2023-01-02")
-
-    for symbol in symbol_list:
+    for symbol in expected_symbols:
         csv_path = tmp_path / f"{symbol}.csv"
         assert csv_path.exists()
         csv_contents = pandas.read_csv(csv_path)
         assert "Date" in csv_contents.columns
-    assert download_calls == symbol_list
+    assert download_calls == expected_symbols


### PR DESCRIPTION
## Summary
- add `SP500_SYMBOL` constant and ensure it is included when updating all data
- extend tests to verify S&P 500 data download and CSV creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68a4a5283234832b95f6eb6d1c666604