### PR TITLE
Add relative strength indicator and tests

### DIFF
--- a/src/stock_indicator/indicators.py
+++ b/src/stock_indicator/indicators.py
@@ -42,6 +42,30 @@ def ema(price_series: pandas.Series, window_size: int) -> pandas.Series:
     return price_series.ewm(span=window_size, adjust=False).mean()
 
 
+# TODO: review
+def relative_strength(
+    price_series: pandas.Series, benchmark_series: pandas.Series
+) -> pandas.Series:
+    """Calculate relative strength versus a benchmark index.
+
+    Parameters
+    ----------
+    price_series: pandas.Series
+        Series of asset prices.
+    benchmark_series: pandas.Series
+        Series of benchmark index prices.
+
+    Returns
+    -------
+    pandas.Series
+        Ratio of the asset price to the benchmark price with aligned indexes.
+    """
+    aligned_price_series, aligned_benchmark_series = price_series.align(
+        benchmark_series, join="inner"
+    )
+    return aligned_price_series.divide(aligned_benchmark_series)
+
+
 def macd(
     price_series: pandas.Series,
     fast_window: int = 12,

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -9,7 +9,7 @@ import pandas
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from stock_indicator.indicators import cci, ema, macd, rsi, sma
+from stock_indicator.indicators import cci, ema, macd, relative_strength, rsi, sma
 
 
 def test_sma_calculates_simple_average() -> None:
@@ -47,6 +47,22 @@ def test_rsi_matches_reference_formula() -> None:
     average_loss_series = loss_series.ewm(alpha=1 / 14, adjust=False).mean()
     relative_strength_series = average_gain_series / average_loss_series
     expected_series = 100 - (100 / (1 + relative_strength_series))
+    pandas.testing.assert_series_equal(result_series, expected_series)
+
+
+# TODO: review
+def test_relative_strength_returns_ratio() -> None:
+    symbol_price_series = pandas.Series(
+        [10, 20, 30], index=pandas.date_range("2020-01-01", periods=3, freq="D")
+    )
+    benchmark_price_series = pandas.Series(
+        [5, 10, 15], index=pandas.date_range("2020-01-02", periods=3, freq="D")
+    )
+    result_series = relative_strength(symbol_price_series, benchmark_price_series)
+    aligned_symbol_series, aligned_benchmark_series = symbol_price_series.align(
+        benchmark_price_series, join="inner"
+    )
+    expected_series = aligned_symbol_series.divide(aligned_benchmark_series)
     pandas.testing.assert_series_equal(result_series, expected_series)
 
 


### PR DESCRIPTION
## Summary
- add relative_strength to calculate price performance against a benchmark with index alignment
- test relative_strength for correct ratio calculation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy -q` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a4a982265c832ba6e1ff5bcd79e1f5