### PR TITLE
feat: allow custom price column

### DIFF
--- a/src/stock_indicator/cli.py
+++ b/src/stock_indicator/cli.py
@@ -1,4 +1,8 @@
-"""Command line interface for running stock simulations."""
+"""Command line interface for running stock simulations.
+
+The interface now supports selecting the price column via the
+``--price-column`` option, which defaults to ``adj_close``.
+"""
 # TODO: review
 
 from __future__ import annotations
@@ -15,7 +19,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 def create_parser() -> argparse.ArgumentParser:
-    """Create the argument parser for the command line interface."""
+    """Create the argument parser for the command line interface.
+
+    The parser includes an optional ``--price-column`` argument that chooses
+    which column from the price data is used for indicator calculations and
+    trading rules. If not provided, ``adj_close`` is used.
+    """
     parser = argparse.ArgumentParser(
         description="Run indicator calculations and trade simulations."
     )
@@ -33,6 +42,14 @@ def create_parser() -> argparse.ArgumentParser:
         help="Trading strategy to apply to the data.",
     )
     parser.add_argument(
+        "--price-column",
+        default="adj_close",
+        help=(
+            "Column in the price data to use for indicator calculations and "
+            "trading rules. Defaults to 'adj_close'."
+        ),
+    )
+    parser.add_argument(
         "--output",
         help="Optional path to a CSV file for writing the trade results.",
     )
@@ -40,7 +57,11 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def run_cli(argument_list: Optional[List[str]] = None) -> None:
-    """Parse command line arguments and execute the selected strategy."""
+    """Parse command line arguments and execute the selected strategy.
+
+    Respects the ``--price-column`` option for choosing the data column used in
+    calculations.
+    """
     parser = create_parser()
     parsed_arguments = parser.parse_args(argument_list)
 
@@ -54,13 +75,19 @@ def run_cli(argument_list: Optional[List[str]] = None) -> None:
     except Exception as symbol_error:  # noqa: BLE001
         LOGGER.warning("Could not verify symbol: %s", symbol_error)
 
-    price_data_frame = data_loader.download_history(
-        parsed_arguments.symbol, parsed_arguments.start, parsed_arguments.end
-    ).rename(columns=str.lower)
+    price_data_frame = (
+        data_loader.download_history(
+            parsed_arguments.symbol, parsed_arguments.start, parsed_arguments.end
+        )
+        .rename(columns=str.lower)
+        .rename(columns=lambda column_name: column_name.replace(" ", "_"))
+    )
+
+    price_column = parsed_arguments.price_column
 
     if parsed_arguments.strategy == "sma":
         indicator_series = indicators.sma(
-            price_data_frame["close"], window_size=20
+            price_data_frame[price_column], window_size=20
         )
         price_data_frame["indicator"] = indicator_series
 
@@ -68,7 +95,7 @@ def run_cli(argument_list: Optional[List[str]] = None) -> None:
             """Determine whether to open a trade for the given row."""
             row_label = current_row.name
             indicator_at_label = indicator_series.loc[row_label]
-            return current_row["close"] > indicator_at_label
+            return current_row[price_column] > indicator_at_label
 
         def exit_rule(
             current_row: pandas.Series, entry_row: pandas.Series
@@ -76,7 +103,7 @@ def run_cli(argument_list: Optional[List[str]] = None) -> None:
             """Determine whether to close the current trade."""
             row_label = current_row.name
             indicator_at_label = indicator_series.loc[row_label]
-            return current_row["close"] < indicator_at_label
+            return current_row[price_column] < indicator_at_label
 
     else:
         raise ValueError(f"Unsupported strategy: {parsed_arguments.strategy}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,7 @@ def test_parser_handles_arguments() -> None:
     assert parsed_arguments.start == "2022-01-01"
     assert parsed_arguments.end == "2022-02-01"
     assert parsed_arguments.strategy == "sma"
+    assert parsed_arguments.price_column == "adj_close"
 
 
 def test_run_cli_invokes_components(
@@ -47,7 +48,7 @@ def test_run_cli_invokes_components(
         assert symbol == "AAA"
         assert start == "2022-01-01"
         assert end == "2022-02-01"
-        return pandas.DataFrame({"close": [1.0, 2.0, 3.0]})
+        return pandas.DataFrame({"Adj Close": [1.0, 2.0, 3.0]})
 
     def fake_sma(price_series: pandas.Series, window_size: int) -> pandas.Series:
         return pandas.Series([1.0, 1.5, 2.0])
@@ -78,3 +79,105 @@ def test_run_cli_invokes_components(
             ]
         )
     assert "Total profit: 5.0" in caplog.text
+
+
+def test_run_cli_uses_adj_close_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI should use the ``adj_close`` column when no option is given."""
+
+    def fake_load_symbols() -> list[str]:
+        return ["AAA"]
+
+    def fake_download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
+        assert symbol == "AAA"
+        assert start == "2022-01-01"
+        assert end == "2022-02-01"
+        return pandas.DataFrame(
+            {"Adj Close": [2.0, 2.0, 2.0], "Close": [-1.0, -1.0, -1.0]}
+        )
+
+    def fake_sma(price_series: pandas.Series, window_size: int) -> pandas.Series:
+        assert price_series.equals(
+            pandas.Series([2.0, 2.0, 2.0], name="adj_close")
+        )
+        return pandas.Series([0.0, 0.0, 0.0])
+
+    def fake_simulate_trades(
+        data_frame: pandas.DataFrame,
+        entry_rule: Callable[[pandas.Series], bool],
+        exit_rule: Callable[[pandas.Series, pandas.Series], bool],
+    ) -> SimulationResult:
+        assert entry_rule(data_frame.iloc[0])
+        assert not exit_rule(data_frame.iloc[0], data_frame.iloc[0])
+        return SimulationResult(trades=[], total_profit=0.0)
+
+    monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)
+    monkeypatch.setattr(cli.data_loader, "download_history", fake_download_history)
+    monkeypatch.setattr(cli.indicators, "sma", fake_sma)
+    monkeypatch.setattr(cli.simulator, "simulate_trades", fake_simulate_trades)
+
+    cli.run_cli(
+        [
+            "--symbol",
+            "AAA",
+            "--start",
+            "2022-01-01",
+            "--end",
+            "2022-02-01",
+            "--strategy",
+            "sma",
+        ]
+    )
+
+
+def test_run_cli_accepts_price_column_argument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI should use the specified column when ``--price-column`` is set."""
+
+    def fake_load_symbols() -> list[str]:
+        return ["AAA"]
+
+    def fake_download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
+        assert symbol == "AAA"
+        assert start == "2022-01-01"
+        assert end == "2022-02-01"
+        return pandas.DataFrame(
+            {"Adj Close": [2.0, 2.0, 2.0], "Close": [-1.0, -1.0, -1.0]}
+        )
+
+    def fake_sma(price_series: pandas.Series, window_size: int) -> pandas.Series:
+        assert price_series.equals(
+            pandas.Series([-1.0, -1.0, -1.0], name="close")
+        )
+        return pandas.Series([0.0, 0.0, 0.0])
+
+    def fake_simulate_trades(
+        data_frame: pandas.DataFrame,
+        entry_rule: Callable[[pandas.Series], bool],
+        exit_rule: Callable[[pandas.Series, pandas.Series], bool],
+    ) -> SimulationResult:
+        assert not entry_rule(data_frame.iloc[0])
+        assert exit_rule(data_frame.iloc[0], data_frame.iloc[0])
+        return SimulationResult(trades=[], total_profit=0.0)
+
+    monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)
+    monkeypatch.setattr(cli.data_loader, "download_history", fake_download_history)
+    monkeypatch.setattr(cli.indicators, "sma", fake_sma)
+    monkeypatch.setattr(cli.simulator, "simulate_trades", fake_simulate_trades)
+
+    cli.run_cli(
+        [
+            "--symbol",
+            "AAA",
+            "--start",
+            "2022-01-01",
+            "--end",
+            "2022-02-01",
+            "--strategy",
+            "sma",
+            "--price-column",
+            "close",
+        ]
+    )


### PR DESCRIPTION
## Summary
- allow choosing price data column via `--price-column` (defaults to `adj_close`)
- normalize downloaded column names to lower case with underscores
- test CLI behavior for default and custom price columns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a58adc5490832bbdc0957d9f9d4cc0