### PR TITLE
Allow simulate_trades to use configurable price column

### DIFF
--- a/src/stock_indicator/cli.py
+++ b/src/stock_indicator/cli.py
@@ -109,7 +109,7 @@ def run_cli(argument_list: Optional[List[str]] = None) -> None:
         raise ValueError(f"Unsupported strategy: {parsed_arguments.strategy}")
 
     simulation_result = simulator.simulate_trades(
-        price_data_frame, entry_rule, exit_rule
+        price_data_frame, entry_rule, exit_rule, price_column
     )
     LOGGER.info("Total profit: %s", simulation_result.total_profit)
     if parsed_arguments.output:

--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -32,18 +32,21 @@ def simulate_trades(
     data: pandas.DataFrame,
     entry_rule: Callable[[pandas.Series], bool],
     exit_rule: Callable[[pandas.Series, pandas.Series], bool],
+    price_column: str = "adj_close",
 ) -> SimulationResult:
     """Simulate trades using supplied entry and exit rules.
 
     Parameters
     ----------
     data: pandas.DataFrame
-        Data frame containing at least a ``close`` column.
+        Data frame containing at least the column specified by ``price_column``.
     entry_rule: Callable[[pandas.Series], bool]
         Function invoked for each row to determine trade entry.
     exit_rule: Callable[[pandas.Series, pandas.Series], bool]
         Function invoked with the current row and the entry row to determine
         when to close the trade.
+    price_column: str, default "adj_close"
+        Column name to use for entry and exit prices.
 
     Returns
     -------
@@ -65,8 +68,8 @@ def simulate_trades(
             if entry_row is None or entry_row_index is None:
                 continue
             if exit_rule(current_row, entry_row):
-                entry_price = float(entry_row["close"])
-                exit_price = float(current_row["close"])
+                entry_price = float(entry_row[price_column])
+                exit_price = float(current_row[price_column])
                 profit_value = exit_price - entry_price
                 trades.append(
                     Trade(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,7 +57,9 @@ def test_run_cli_invokes_components(
         data_frame: pandas.DataFrame,
         entry_rule: Callable[[pandas.Series], bool],
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
+        price_column: str = "adj_close",
     ) -> SimulationResult:
+        assert price_column == "adj_close"
         return SimulationResult(trades=[], total_profit=5.0)
 
     monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)
@@ -107,7 +109,9 @@ def test_run_cli_uses_adj_close_by_default(
         data_frame: pandas.DataFrame,
         entry_rule: Callable[[pandas.Series], bool],
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
+        price_column: str = "adj_close",
     ) -> SimulationResult:
+        assert price_column == "adj_close"
         assert entry_rule(data_frame.iloc[0])
         assert not exit_rule(data_frame.iloc[0], data_frame.iloc[0])
         return SimulationResult(trades=[], total_profit=0.0)
@@ -157,7 +161,9 @@ def test_run_cli_accepts_price_column_argument(
         data_frame: pandas.DataFrame,
         entry_rule: Callable[[pandas.Series], bool],
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
+        price_column: str = "adj_close",
     ) -> SimulationResult:
+        assert price_column == "close"
         assert not entry_rule(data_frame.iloc[0])
         assert exit_rule(data_frame.iloc[0], data_frame.iloc[0])
         return SimulationResult(trades=[], total_profit=0.0)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -13,22 +13,24 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 from stock_indicator.simulator import SimulationResult, simulate_trades
 
 
-def test_simulate_trades_executes_trade_flow() -> None:
-    data = pandas.DataFrame({"close": [100.0, 102.0, 104.0, 103.0, 106.0]})
+def test_simulate_trades_executes_trade_flow_with_default_column() -> None:
+    price_data_frame = pandas.DataFrame(
+        {"adj_close": [100.0, 102.0, 104.0, 103.0, 106.0]}
+    )
 
     def entry_rule(current_row: pandas.Series) -> bool:
-        return current_row["close"] > 101.0
+        return current_row["adj_close"] > 101.0
 
     def exit_rule(current_row: pandas.Series, entry_row: pandas.Series) -> bool:
-        return current_row["close"] > 105.0
+        return current_row["adj_close"] > 105.0
 
-    result = simulate_trades(data, entry_rule, exit_rule)
+    result = simulate_trades(price_data_frame, entry_rule, exit_rule)
 
     assert isinstance(result, SimulationResult)
     assert len(result.trades) == 1
     completed_trade = result.trades[0]
-    expected_entry_date = data.index[1]
-    expected_exit_date = data.index[4]
+    expected_entry_date = price_data_frame.index[1]
+    expected_exit_date = price_data_frame.index[4]
     assert completed_trade.entry_date == expected_entry_date
     assert completed_trade.exit_date == expected_exit_date
     assert completed_trade.entry_price == 102.0
@@ -66,7 +68,9 @@ def test_simulate_trades_with_sma_strategy_uses_aligned_labels() -> None:
             return False
         return current_row["close"] < indicator_at_label
 
-    result = simulate_trades(price_data_frame, entry_rule, exit_rule)
+    result = simulate_trades(
+        price_data_frame, entry_rule, exit_rule, price_column="close"
+    )
 
     assert isinstance(result, SimulationResult)
     assert len(result.trades) == 1


### PR DESCRIPTION
## Summary
- add price_column param to simulate_trades (default adj_close)
- pass price column from CLI
- test simulator with adj_close and close columns

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a58d1d365c832bb8bfcd5067cf9358