### PR TITLE
Add EMA/SMA cross strategy evaluation

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -11,7 +11,7 @@ from typing import List
 
 from pandas import DataFrame
 
-from . import data_loader, symbols
+from . import data_loader, symbols, strategy
 
 LOGGER = logging.getLogger(__name__)
 
@@ -69,6 +69,29 @@ class StockShell(cmd.Cmd):
             output_path = DATA_DIRECTORY / f"{symbol_name}.csv"
             data_frame_with_date.to_csv(output_path, index=False)
             self.stdout.write(f"Data written to {output_path}\n")
+
+    # TODO: review
+    def do_start_simulate(self, argument_line: str) -> None:  # noqa: D401
+        """start_simulate BUY_STRATEGY SELL_STRATEGY\n        Evaluate trading strategies using cached data."""
+        argument_parts: List[str] = argument_line.split()
+        if len(argument_parts) != 2:
+            self.stdout.write(
+                "usage: start_simulate BUY_STRATEGY SELL_STRATEGY\n"
+            )
+            return
+        buy_strategy_name, sell_strategy_name = argument_parts
+        if (
+            buy_strategy_name != "ema_sma_cross"
+            or sell_strategy_name != "ema_sma_cross"
+        ):
+            self.stdout.write("unsupported strategies\n")
+            return
+        trade_count, win_rate = strategy.evaluate_ema_sma_cross_strategy(
+            DATA_DIRECTORY
+        )
+        self.stdout.write(
+            f"Trades: {trade_count}, Win rate: {win_rate:.2%}\n"
+        )
 
     def do_exit(self, argument_line: str) -> bool:  # noqa: D401
         """exit\n        Exit the shell."""

--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -32,21 +32,25 @@ def simulate_trades(
     data: pandas.DataFrame,
     entry_rule: Callable[[pandas.Series], bool],
     exit_rule: Callable[[pandas.Series, pandas.Series], bool],
-    price_column: str = "adj_close",
+    entry_price_column: str = "adj_close",
+    exit_price_column: str | None = None,
 ) -> SimulationResult:
     """Simulate trades using supplied entry and exit rules.
 
     Parameters
     ----------
     data: pandas.DataFrame
-        Data frame containing at least the column specified by ``price_column``.
+        Data frame containing the price data.
     entry_rule: Callable[[pandas.Series], bool]
         Function invoked for each row to determine trade entry.
     exit_rule: Callable[[pandas.Series, pandas.Series], bool]
         Function invoked with the current row and the entry row to determine
         when to close the trade.
-    price_column: str, default "adj_close"
-        Column name to use for entry and exit prices.
+    entry_price_column: str, default "adj_close"
+        Column name used for calculating entry price.
+    exit_price_column: str, optional
+        Column name used for calculating exit price. When ``None``,
+        ``entry_price_column`` is used for both entry and exit prices.
 
     Returns
     -------
@@ -68,8 +72,11 @@ def simulate_trades(
             if entry_row is None or entry_row_index is None:
                 continue
             if exit_rule(current_row, entry_row):
-                entry_price = float(entry_row[price_column])
-                exit_price = float(current_row[price_column])
+                entry_price = float(entry_row[entry_price_column])
+                price_column_name = (
+                    exit_price_column if exit_price_column is not None else entry_price_column
+                )
+                exit_price = float(current_row[price_column_name])
                 profit_value = exit_price - entry_price
                 trades.append(
                     Trade(

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,27 @@
+"""Tests for strategy evaluation utilities."""
+# TODO: review
+
+import os
+import sys
+from pathlib import Path
+
+import pandas
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from stock_indicator.strategy import evaluate_ema_sma_cross_strategy
+
+
+def test_evaluate_ema_sma_cross_strategy_computes_win_rate(tmp_path: Path) -> None:
+    price_values = [10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 10.0, 10.0, 10.0]
+    date_index = pandas.date_range("2020-01-01", periods=len(price_values), freq="D")
+    price_data_frame = pandas.DataFrame(
+        {"Date": date_index, "open": price_values, "adj_close": price_values}
+    )
+    csv_path = tmp_path / "test.csv"
+    price_data_frame.to_csv(csv_path, index=False)
+
+    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+
+    assert total_trades == 1
+    assert win_rate == 0.0


### PR DESCRIPTION
## Summary
- extend trade simulator to support separate entry and exit price columns
- add utility to evaluate a 15-day EMA/SMA cross strategy across data files
- add shell command to run EMA/SMA cross strategy evaluation
- cover simulator, strategy evaluation, and management shell with tests

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `pip install pandas yfinance requests pytest -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68a5cb3f4df8832bbc9df44f9f1d38fa