### PR TITLE
Remove adj_close handling in favor of yfinance-adjusted close

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ prices["rsi_14"] = rsi(prices["close"], window=14)
 print(prices[["close", "rsi_14"]].tail())
 ```
 
-Downloaded data frames use lower-case ``snake_case`` column names. For instance,
-``"Adj Close"`` is exposed as ``"adj_close"``. If the source data lacks an
-adjusted closing price column, the loader derives one from ``"close"`` and
-``"stock_splits"`` and logs a warning indicating that the series was
-synthesized. Downstream code should refer to columns using this standardized
+Downloaded data frames use lower-case ``snake_case`` column names. With
+``yfinance`` version ``0.2.51`` and later, the ``close`` column already reflects
+dividends and stock splits, so no separate adjusted closing price column is
+provided. Downstream code should refer to columns using this standardized
 style.
 
 ### Command Line Example

--- a/src/stock_indicator/cli.py
+++ b/src/stock_indicator/cli.py
@@ -1,7 +1,7 @@
 """Command line interface for running stock simulations.
 
-The interface now supports selecting the price column via the
-``--price-column`` option, which defaults to ``adj_close``.
+The interface allows selecting the price column via the ``--price-column``
+option, which defaults to ``close``.
 """
 # TODO: review
 
@@ -23,7 +23,7 @@ def create_parser() -> argparse.ArgumentParser:
 
     The parser includes an optional ``--price-column`` argument that chooses
     which column from the price data is used for indicator calculations and
-    trading rules. If not provided, ``adj_close`` is used.
+    trading rules. If not provided, ``close`` is used.
     """
     parser = argparse.ArgumentParser(
         description="Run indicator calculations and trade simulations."
@@ -43,10 +43,10 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--price-column",
-        default="adj_close",
+        default="close",
         help=(
             "Column in the price data to use for indicator calculations and "
-            "trading rules. Defaults to 'adj_close'."
+            "trading rules. Defaults to 'close'."
         ),
     )
     parser.add_argument(

--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -32,7 +32,7 @@ def simulate_trades(
     data: pandas.DataFrame,
     entry_rule: Callable[[pandas.Series], bool],
     exit_rule: Callable[[pandas.Series, pandas.Series], bool],
-    entry_price_column: str = "adj_close",
+    entry_price_column: str = "close",
     exit_price_column: str | None = None,
 ) -> SimulationResult:
     """Simulate trades using supplied entry and exit rules.
@@ -46,7 +46,7 @@ def simulate_trades(
     exit_rule: Callable[[pandas.Series, pandas.Series], bool]
         Function invoked with the current row and the entry row to determine
         when to close the trade.
-    entry_price_column: str, default "adj_close"
+    entry_price_column: str, default "close"
         Column name used for calculating entry price.
     exit_price_column: str, optional
         Column name used for calculating exit price. When ``None``,

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -23,12 +23,12 @@ def evaluate_ema_sma_cross_strategy(
     exponential moving average crosses above the simple moving average and the
     position is opened at the next day's opening price. The position is closed
     when the exponential moving average crosses below the simple moving average,
-    using the next day's adjusted closing price.
+    using the next day's closing price.
 
     Parameters
     ----------
     data_directory: Path
-        Directory containing CSV files with columns ``open`` and ``adj_close``.
+        Directory containing CSV files with columns ``open`` and ``close``.
     window_size: int, default 15
         Number of periods to use for both EMA and SMA calculations.
 
@@ -42,8 +42,8 @@ def evaluate_ema_sma_cross_strategy(
         price_data_frame = pandas.read_csv(
             csv_path, parse_dates=["Date"], index_col="Date"
         )
-        price_data_frame["ema_value"] = ema(price_data_frame["adj_close"], window_size)
-        price_data_frame["sma_value"] = sma(price_data_frame["adj_close"], window_size)
+        price_data_frame["ema_value"] = ema(price_data_frame["close"], window_size)
+        price_data_frame["sma_value"] = sma(price_data_frame["close"], window_size)
         price_data_frame["ema_previous"] = price_data_frame["ema_value"].shift(1)
         price_data_frame["sma_previous"] = price_data_frame["sma_value"].shift(1)
         price_data_frame["cross_up"] = (
@@ -70,7 +70,7 @@ def evaluate_ema_sma_cross_strategy(
             entry_rule=entry_rule,
             exit_rule=exit_rule,
             entry_price_column="open",
-            exit_price_column="adj_close",
+            exit_price_column="close",
         )
         for completed_trade in simulation_result.trades:
             trade_profit_list.append(completed_trade.profit)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -15,14 +15,14 @@ from stock_indicator.simulator import SimulationResult, simulate_trades
 
 def test_simulate_trades_executes_trade_flow_with_default_column() -> None:
     price_data_frame = pandas.DataFrame(
-        {"adj_close": [100.0, 102.0, 104.0, 103.0, 106.0]}
+        {"close": [100.0, 102.0, 104.0, 103.0, 106.0]}
     )
 
     def entry_rule(current_row: pandas.Series) -> bool:
-        return current_row["adj_close"] > 101.0
+        return current_row["close"] > 101.0
 
     def exit_rule(current_row: pandas.Series, entry_row: pandas.Series) -> bool:
-        return current_row["adj_close"] > 105.0
+        return current_row["close"] > 105.0
 
     result = simulate_trades(price_data_frame, entry_rule, exit_rule)
 
@@ -87,21 +87,21 @@ def test_simulate_trades_with_sma_strategy_uses_aligned_labels() -> None:
 
 def test_simulate_trades_handles_distinct_entry_and_exit_price_columns() -> None:
     price_data_frame = pandas.DataFrame(
-        {"open": [10.0, 12.0], "adj_close": [11.0, 13.0]}
+        {"open": [10.0, 12.0], "close": [11.0, 13.0]}
     )
 
     def entry_rule(current_row: pandas.Series) -> bool:
         return current_row["open"] == 10.0
 
     def exit_rule(current_row: pandas.Series, entry_row: pandas.Series) -> bool:
-        return current_row["adj_close"] >= 13.0
+        return current_row["close"] >= 13.0
 
     result = simulate_trades(
         price_data_frame,
         entry_rule,
         exit_rule,
         entry_price_column="open",
-        exit_price_column="adj_close",
+        exit_price_column="close",
     )
 
     assert isinstance(result, SimulationResult)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -16,7 +16,7 @@ def test_evaluate_ema_sma_cross_strategy_computes_win_rate(tmp_path: Path) -> No
     price_values = [10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 10.0, 10.0, 10.0]
     date_index = pandas.date_range("2020-01-01", periods=len(price_values), freq="D")
     price_data_frame = pandas.DataFrame(
-        {"Date": date_index, "open": price_values, "adj_close": price_values}
+        {"Date": date_index, "open": price_values, "close": price_values}
     )
     csv_path = tmp_path / "test.csv"
     price_data_frame.to_csv(csv_path, index=False)


### PR DESCRIPTION
## Summary
- simplify data loader to rely on yfinance's adjusted close, removing adj_close column synthesis
- default CLI and simulator pricing to `close`
- update strategy and documentation to reference `close`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a6062d5520832b976dce53ed2d1973