### PR TITLE
Ensure S&P 500 symbol is always loaded

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -12,11 +12,11 @@ from typing import List
 from pandas import DataFrame
 
 from . import data_loader, symbols, strategy
+from .symbols import SP500_SYMBOL
 
 LOGGER = logging.getLogger(__name__)
 
 DATA_DIRECTORY = Path(__file__).resolve().parent.parent.parent / "data"
-SP500_SYMBOL = "^GSPC"  # TODO: review
 
 
 class StockShell(cmd.Cmd):

--- a/src/stock_indicator/symbols.py
+++ b/src/stock_indicator/symbols.py
@@ -17,6 +17,9 @@ SYMBOL_CACHE_PATH = (
     Path(__file__).resolve().parent.parent.parent / "data" / "symbols.txt"
 )
 
+# Symbol representing the S&P 500 index.
+SP500_SYMBOL = "^GSPC"
+
 
 def update_symbol_cache() -> None:
     """Download the latest symbol list and store it locally.
@@ -57,5 +60,7 @@ def load_symbols() -> list[str]:
         ):
             raise ValueError("Symbol cache JSON must be a list of strings.")
         symbol_list = parsed_symbols
+    if SP500_SYMBOL not in symbol_list:
+        symbol_list.append(SP500_SYMBOL)
     return symbol_list
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -69,7 +69,7 @@ def test_update_all_data(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
     """The command should download data for every symbol in the cache."""
     import stock_indicator.manage as manage_module
 
-    symbol_list = ["AAA", "BBB"]
+    symbol_list = ["AAA", "BBB", manage_module.SP500_SYMBOL]
 
     def fake_load_symbols() -> list[str]:
         return symbol_list
@@ -88,7 +88,7 @@ def test_update_all_data(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
     )
     monkeypatch.setattr(manage_module, "DATA_DIRECTORY", tmp_path)
 
-    expected_symbols = symbol_list + [manage_module.SP500_SYMBOL]
+    expected_symbols = symbol_list
     shell = manage_module.StockShell(stdout=io.StringIO())
     shell.onecmd("update_all_data 2023-01-01 2023-01-02")
     for symbol in expected_symbols:

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -48,10 +48,11 @@ def test_load_symbols_fetches_and_caches_json(
     monkeypatch.setattr(symbols_module, "SYMBOL_CACHE_PATH", cache_path)
 
     symbol_list = symbols_module.load_symbols()
-    assert symbol_list == mock_symbol_list
+    expected_list = mock_symbol_list + [symbols_module.SP500_SYMBOL]
+    assert symbol_list == expected_list
     assert cache_path.exists()
 
     symbol_list_second = symbols_module.load_symbols()
-    assert symbol_list_second == mock_symbol_list
+    assert symbol_list_second == expected_list
     assert request_call_count["count"] == 1
 


### PR DESCRIPTION
## Summary
- add `SP500_SYMBOL` constant to `symbols` module and ensure it's included in the loaded symbol list
- use shared `SP500_SYMBOL` constant in management shell
- update tests for new symbol behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a6123b2380832b897b9970d064c478