### PR TITLE
Handle ticker suffixes in column names

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -51,8 +51,13 @@ def evaluate_ema_sma_cross_strategy(
             re.sub(r"[^a-z0-9]+", "_", str(column_name).strip().lower())
             for column_name in price_data_frame.columns
         ]
+        # Remove trailing ticker identifiers such as "_riv" so that column names
+        # are reduced to plain identifiers like "open" and "close"
+        price_data_frame.columns = [
+            re.sub(r"(open|close|high|low|volume)_.*", r"\1", column_name)
+            for column_name in price_data_frame.columns
+        ]
         required_columns = {"open", "close"}
-        print(price_data_frame.columns)
         missing_column_names = [
             required_column
             for required_column in required_columns

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -43,13 +43,28 @@ def test_evaluate_ema_sma_cross_strategy_normalizes_headers(tmp_path: Path) -> N
     assert win_rate == 0.0
 
 
+def test_evaluate_ema_sma_cross_strategy_removes_ticker_suffix(tmp_path: Path) -> None:
+    price_value_list = [10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 10.0, 10.0, 10.0]
+    date_index = pandas.date_range("2020-01-01", periods=len(price_value_list), freq="D")
+    price_data_frame = pandas.DataFrame(
+        {"Date": date_index, "Open RIV": price_value_list, "Close RIV": price_value_list}
+    )
+    csv_path = tmp_path / "ticker_suffix.csv"
+    price_data_frame.to_csv(csv_path, index=False)
+
+    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+
+    assert total_trades == 1
+    assert win_rate == 0.0
+
+
 def test_evaluate_ema_sma_cross_strategy_raises_value_error_for_missing_columns(
     tmp_path: Path,
 ) -> None:
     price_values = [10.0, 10.0, 10.0]
     date_index = pandas.date_range("2020-01-01", periods=len(price_values), freq="D")
     price_data_frame = pandas.DataFrame(
-        {"Date": date_index, "Open Price": price_values, "Close Price": price_values}
+        {"Date": date_index, "Opening Price": price_values, "Closing Price": price_values}
     )
     csv_path = tmp_path / "test_missing.csv"
     price_data_frame.to_csv(csv_path, index=False)


### PR DESCRIPTION
## Summary
- Clean normalized CSV headers by stripping trailing ticker identifiers so required `open`/`close` columns are detected
- Test handling of headers with ticker suffixes like `Open RIV`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a8488026dc832b8a670f9e4ff1257a