### PR TITLE
Use fill_value in signal shift and fix header suffix stripping

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -54,7 +54,7 @@ def evaluate_ema_sma_cross_strategy(
         # Remove trailing ticker identifiers such as "_riv" so that column names
         # are reduced to plain identifiers like "open" and "close"
         price_data_frame.columns = [
-            re.sub(r"_(open|close|high|low|volume)_.*", r"\1", column_name)
+            re.sub(r"(open|close|high|low|volume)_[a-z0-9]+$", r"\1", column_name)
             for column_name in price_data_frame.columns
         ]
         required_columns = {"open", "close"}
@@ -80,8 +80,8 @@ def evaluate_ema_sma_cross_strategy(
             (price_data_frame["ema_previous"] >= price_data_frame["sma_previous"])
             & (price_data_frame["ema_value"] < price_data_frame["sma_value"])
         )
-        price_data_frame["entry_signal"] = price_data_frame["cross_up"].shift(1).fillna(False)
-        price_data_frame["exit_signal"] = price_data_frame["cross_down"].shift(1).fillna(False)
+        price_data_frame["entry_signal"] = price_data_frame["cross_up"].shift(1, fill_value=False)
+        price_data_frame["exit_signal"] = price_data_frame["cross_down"].shift(1, fill_value=False)
 
         def entry_rule(current_row: pandas.Series) -> bool:
             return bool(current_row["entry_signal"])


### PR DESCRIPTION
## Summary
- avoid pandas warning by passing `fill_value=False` directly to `shift`
- strip ticker suffixes from column names using a more robust regex

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a86c6bbb80832bbe735728b0658724