### PR TITLE
Remove RS requirement from EMA/SMA strategy

### DIFF
--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -14,14 +14,26 @@ from stock_indicator.strategy import evaluate_ema_sma_cross_strategy
 
 
 def test_evaluate_ema_sma_cross_strategy_computes_win_rate(tmp_path: Path) -> None:
-    price_values = [10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 10.0, 10.0, 10.0]
+    initial_price_values = [10.0] * 150
+    pattern_price_values = [
+        10.0,
+        10.0,
+        10.0,
+        10.0,
+        20.0,
+        20.0,
+        20.0,
+        10.0,
+        10.0,
+        10.0,
+    ]
+    price_values = initial_price_values + pattern_price_values
     date_index = pandas.date_range("2020-01-01", periods=len(price_values), freq="D")
     price_data_frame = pandas.DataFrame(
         {
             "Date": date_index,
             "open": price_values,
             "close": price_values,
-            "rs": [96.0] * len(price_values),
         }
     )
     csv_path = tmp_path / "test.csv"
@@ -34,14 +46,26 @@ def test_evaluate_ema_sma_cross_strategy_computes_win_rate(tmp_path: Path) -> No
 
 
 def test_evaluate_ema_sma_cross_strategy_normalizes_headers(tmp_path: Path) -> None:
-    price_values = [10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 10.0, 10.0, 10.0]
+    initial_price_values = [10.0] * 150
+    pattern_price_values = [
+        10.0,
+        10.0,
+        10.0,
+        10.0,
+        20.0,
+        20.0,
+        20.0,
+        10.0,
+        10.0,
+        10.0,
+    ]
+    price_values = initial_price_values + pattern_price_values
     date_index = pandas.date_range("2020-01-01", periods=len(price_values), freq="D")
     price_data_frame = pandas.DataFrame(
         {
             "Date": date_index,
             "OPEN": price_values,
             "CLOSE": price_values,
-            "RS": [96.0] * len(price_values),
         }
     )
     csv_path = tmp_path / "test_uppercase.csv"
@@ -54,14 +78,26 @@ def test_evaluate_ema_sma_cross_strategy_normalizes_headers(tmp_path: Path) -> N
 
 
 def test_evaluate_ema_sma_cross_strategy_removes_ticker_suffix(tmp_path: Path) -> None:
-    price_value_list = [10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 10.0, 10.0, 10.0]
+    initial_price_values = [10.0] * 150
+    pattern_price_values = [
+        10.0,
+        10.0,
+        10.0,
+        10.0,
+        20.0,
+        20.0,
+        20.0,
+        10.0,
+        10.0,
+        10.0,
+    ]
+    price_value_list = initial_price_values + pattern_price_values
     date_index = pandas.date_range("2020-01-01", periods=len(price_value_list), freq="D")
     price_data_frame = pandas.DataFrame(
         {
             "Date": date_index,
             "Open RIV": price_value_list,
             "Close RIV": price_value_list,
-            "RS": [96.0] * len(price_value_list),
         }
     )
     csv_path = tmp_path / "ticker_suffix.csv"
@@ -73,15 +109,29 @@ def test_evaluate_ema_sma_cross_strategy_removes_ticker_suffix(tmp_path: Path) -
     assert win_rate == 0.0
 
 
-def test_evaluate_ema_sma_cross_strategy_strips_leading_underscore(tmp_path: Path) -> None:
-    price_value_list = [10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 10.0, 10.0, 10.0]
+def test_evaluate_ema_sma_cross_strategy_strips_leading_underscore(
+    tmp_path: Path,
+) -> None:
+    initial_price_values = [10.0] * 150
+    pattern_price_values = [
+        10.0,
+        10.0,
+        10.0,
+        10.0,
+        20.0,
+        20.0,
+        20.0,
+        10.0,
+        10.0,
+        10.0,
+    ]
+    price_value_list = initial_price_values + pattern_price_values
     date_index = pandas.date_range("2020-01-01", periods=len(price_value_list), freq="D")
     price_data_frame = pandas.DataFrame(
         {
             "Date": date_index,
             "_Open RIV": price_value_list,
             "_Close RIV": price_value_list,
-            "RS": [96.0] * len(price_value_list),
         }
     )
     csv_path = tmp_path / "leading_underscore.csv"
@@ -111,7 +161,8 @@ def test_evaluate_ema_sma_cross_strategy_raises_value_error_for_missing_columns(
 def test_evaluate_ema_sma_cross_strategy_handles_multiindex(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    price_value_list = [
+    initial_price_values = [10.0] * 150
+    pattern_price_values = [
         10.0,
         10.0,
         10.0,
@@ -123,13 +174,13 @@ def test_evaluate_ema_sma_cross_strategy_handles_multiindex(
         10.0,
         10.0,
     ]
+    price_value_list = initial_price_values + pattern_price_values
     date_index = pandas.date_range("2020-01-01", periods=len(price_value_list), freq="D")
     price_data_frame = pandas.DataFrame(
         {
             ("Date", ""): date_index,
             ("OPEN", "ignore"): price_value_list,
             ("CLOSE", "ignore"): price_value_list,
-            ("RS", "ignore"): [96.0] * len(price_value_list),
         }
     )
     csv_path = tmp_path / "multi_index.csv"
@@ -153,20 +204,32 @@ def test_evaluate_ema_sma_cross_strategy_handles_multiindex(
     assert win_rate == 0.0
 
 
-def test_evaluate_ema_sma_cross_strategy_requires_high_relative_strength(
+def test_evaluate_ema_sma_cross_strategy_requires_close_above_long_term_sma(
     tmp_path: Path,
 ) -> None:
-    price_values = [10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 10.0, 10.0, 10.0]
+    initial_price_values = [20.0] * 150
+    pattern_price_values = [
+        20.0,
+        20.0,
+        20.0,
+        20.0,
+        10.0,
+        10.0,
+        10.0,
+        20.0,
+        20.0,
+        20.0,
+    ]
+    price_values = initial_price_values + pattern_price_values
     date_index = pandas.date_range("2020-01-01", periods=len(price_values), freq="D")
     price_data_frame = pandas.DataFrame(
         {
             "Date": date_index,
             "open": price_values,
             "close": price_values,
-            "rs": [80.0] * len(price_values),
         }
     )
-    csv_path = tmp_path / "low_rs.csv"
+    csv_path = tmp_path / "below_long_sma.csv"
     price_data_frame.to_csv(csv_path, index=False)
 
     total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
@@ -175,7 +238,7 @@ def test_evaluate_ema_sma_cross_strategy_requires_high_relative_strength(
     assert win_rate == 0.0
 
 
-def test_evaluate_ema_sma_cross_strategy_computes_missing_relative_strength(
+def test_evaluate_ema_sma_cross_strategy_ignores_missing_relative_strength(
     tmp_path: Path,
 ) -> None:
     price_values = [10.0, 11.0, 12.0, 13.0, 14.0, 15.0]
@@ -194,4 +257,4 @@ def test_evaluate_ema_sma_cross_strategy_computes_missing_relative_strength(
 
     assert (total_trades, win_rate) == (0, 0.0)
     updated_data_frame = pandas.read_csv(csv_path)
-    assert "rs" in updated_data_frame.columns
+    assert "rs" not in updated_data_frame.columns


### PR DESCRIPTION
## Summary
- remove relative strength check from EMA/SMA cross strategy
- require prior close to exceed 150-day SMA before entering trades
- adjust strategy tests for new long-term SMA rule

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a8aed64578832ba6453ae237230f57