### PR TITLE
Add profit and loss percentage statistics to strategy evaluation

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -122,11 +122,18 @@ class StockShell(cmd.Cmd):
         ):
             self.stdout.write("unsupported strategies\n")
             return
-        trade_count, win_rate = strategy.evaluate_ema_sma_cross_strategy(
+        evaluation_metrics = strategy.evaluate_ema_sma_cross_strategy(
             DATA_DIRECTORY
         )
         self.stdout.write(
-            f"Trades: {trade_count}, Win rate: {win_rate:.2%}\n"
+            (
+                f"Trades: {evaluation_metrics.total_trades}, "
+                f"Win rate: {evaluation_metrics.win_rate:.2%}, "
+                f"Mean profit %: {evaluation_metrics.mean_profit_percentage:.2%}, "
+                f"Profit % Std Dev: {evaluation_metrics.profit_percentage_standard_deviation:.2%}, "
+                f"Mean loss %: {evaluation_metrics.mean_loss_percentage:.2%}, "
+                f"Loss % Std Dev: {evaluation_metrics.loss_percentage_standard_deviation:.2%}\n"
+            )
         )
 
     # TODO: review

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -105,10 +105,19 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
 
     call_record: dict[str, bool] = {"called": False}
 
-    def fake_evaluate(data_directory: Path) -> tuple[int, float]:
+    from stock_indicator.strategy import StrategyMetrics
+
+    def fake_evaluate(data_directory: Path) -> StrategyMetrics:
         call_record["called"] = True
         assert data_directory == manage_module.DATA_DIRECTORY
-        return 3, 0.5
+        return StrategyMetrics(
+            total_trades=3,
+            win_rate=0.5,
+            mean_profit_percentage=0.1,
+            profit_percentage_standard_deviation=0.0,
+            mean_loss_percentage=0.05,
+            loss_percentage_standard_deviation=0.0,
+        )
 
     monkeypatch.setattr(
         manage_module.strategy,
@@ -120,4 +129,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     shell = manage_module.StockShell(stdout=output_buffer)
     shell.onecmd("start_simulate ema_sma_cross ema_sma_cross")
     assert call_record["called"] is True
-    assert "Trades: 3, Win rate: 50.00%" in output_buffer.getvalue()
+    assert (
+        "Trades: 3, Win rate: 50.00%, Mean profit %: 10.00%, Profit % Std Dev: 0.00%, "
+        "Mean loss %: 5.00%, Loss % Std Dev: 0.00%" in output_buffer.getvalue()
+    )

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -10,6 +10,9 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
+import stock_indicator.strategy as strategy
+from stock_indicator.simulator import SimulationResult, Trade
+
 from stock_indicator.strategy import evaluate_ema_sma_cross_strategy
 
 
@@ -39,10 +42,10 @@ def test_evaluate_ema_sma_cross_strategy_computes_win_rate(tmp_path: Path) -> No
     csv_path = tmp_path / "test.csv"
     price_data_frame.to_csv(csv_path, index=False)
 
-    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+    result = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
 
-    assert total_trades == 1
-    assert win_rate == 0.0
+    assert result.total_trades == 1
+    assert result.win_rate == 0.0
 
 
 def test_evaluate_ema_sma_cross_strategy_normalizes_headers(tmp_path: Path) -> None:
@@ -71,10 +74,10 @@ def test_evaluate_ema_sma_cross_strategy_normalizes_headers(tmp_path: Path) -> N
     csv_path = tmp_path / "test_uppercase.csv"
     price_data_frame.to_csv(csv_path, index=False)
 
-    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+    result = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
 
-    assert total_trades == 1
-    assert win_rate == 0.0
+    assert result.total_trades == 1
+    assert result.win_rate == 0.0
 
 
 def test_evaluate_ema_sma_cross_strategy_removes_ticker_suffix(tmp_path: Path) -> None:
@@ -103,10 +106,10 @@ def test_evaluate_ema_sma_cross_strategy_removes_ticker_suffix(tmp_path: Path) -
     csv_path = tmp_path / "ticker_suffix.csv"
     price_data_frame.to_csv(csv_path, index=False)
 
-    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+    result = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
 
-    assert total_trades == 1
-    assert win_rate == 0.0
+    assert result.total_trades == 1
+    assert result.win_rate == 0.0
 
 
 def test_evaluate_ema_sma_cross_strategy_strips_leading_underscore(
@@ -137,10 +140,10 @@ def test_evaluate_ema_sma_cross_strategy_strips_leading_underscore(
     csv_path = tmp_path / "leading_underscore.csv"
     price_data_frame.to_csv(csv_path, index=False)
 
-    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+    result = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
 
-    assert total_trades == 1
-    assert win_rate == 0.0
+    assert result.total_trades == 1
+    assert result.win_rate == 0.0
 
 
 def test_evaluate_ema_sma_cross_strategy_raises_value_error_for_missing_columns(
@@ -198,10 +201,10 @@ def test_evaluate_ema_sma_cross_strategy_handles_multiindex(
         )
 
     monkeypatch.setattr(pandas, "read_csv", patched_read_csv)
-    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+    result = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
 
-    assert total_trades == 1
-    assert win_rate == 0.0
+    assert result.total_trades == 1
+    assert result.win_rate == 0.0
 
 
 def test_evaluate_ema_sma_cross_strategy_requires_close_above_long_term_sma(
@@ -232,10 +235,10 @@ def test_evaluate_ema_sma_cross_strategy_requires_close_above_long_term_sma(
     csv_path = tmp_path / "below_long_sma.csv"
     price_data_frame.to_csv(csv_path, index=False)
 
-    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+    result = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
 
-    assert total_trades == 0
-    assert win_rate == 0.0
+    assert result.total_trades == 0
+    assert result.win_rate == 0.0
 
 
 def test_evaluate_ema_sma_cross_strategy_ignores_missing_relative_strength(
@@ -253,8 +256,56 @@ def test_evaluate_ema_sma_cross_strategy_ignores_missing_relative_strength(
     csv_path = tmp_path / "missing_rs.csv"
     price_data_frame.to_csv(csv_path, index=False)
 
-    total_trades, win_rate = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+    result = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
 
-    assert (total_trades, win_rate) == (0, 0.0)
+    assert (result.total_trades, result.win_rate) == (0, 0.0)
     updated_data_frame = pandas.read_csv(csv_path)
     assert "rs" not in updated_data_frame.columns
+
+
+def test_evaluate_ema_sma_cross_strategy_computes_profit_and_loss_statistics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    price_values = [10.0] * 160
+    date_index = pandas.date_range("2020-01-01", periods=len(price_values), freq="D")
+    price_data_frame = pandas.DataFrame(
+        {
+            "Date": date_index,
+            "open": price_values,
+            "close": price_values,
+        }
+    )
+    csv_path = tmp_path / "statistics.csv"
+    price_data_frame.to_csv(csv_path, index=False)
+
+    trades = [
+        Trade(
+            entry_date=date_index[0],
+            exit_date=date_index[1],
+            entry_price=10.0,
+            exit_price=12.0,
+            profit=2.0,
+        ),
+        Trade(
+            entry_date=date_index[2],
+            exit_date=date_index[3],
+            entry_price=10.0,
+            exit_price=9.0,
+            profit=-1.0,
+        ),
+    ]
+    simulation_result = SimulationResult(trades=trades, total_profit=1.0)
+
+    def fake_simulate_trades(*args: object, **kwargs: object) -> SimulationResult:
+        return simulation_result
+
+    monkeypatch.setattr(strategy, "simulate_trades", fake_simulate_trades)
+
+    result = evaluate_ema_sma_cross_strategy(tmp_path, window_size=3)
+
+    assert result.total_trades == 2
+    assert result.win_rate == 0.5
+    assert result.mean_profit_percentage == pytest.approx(0.2)
+    assert result.profit_percentage_standard_deviation == 0.0
+    assert result.mean_loss_percentage == pytest.approx(0.1)
+    assert result.loss_percentage_standard_deviation == 0.0


### PR DESCRIPTION
## Summary
- track additional trade metrics including mean and standard deviation for profit and loss percentages
- expose these new statistics through the management shell
- cover profit and loss statistics with dedicated unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a92be70640832bbe13f4597d1f9169