### PR TITLE
Add holding period statistics to trading metrics

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -132,7 +132,9 @@ class StockShell(cmd.Cmd):
                 f"Mean profit %: {evaluation_metrics.mean_profit_percentage:.2%}, "
                 f"Profit % Std Dev: {evaluation_metrics.profit_percentage_standard_deviation:.2%}, "
                 f"Mean loss %: {evaluation_metrics.mean_loss_percentage:.2%}, "
-                f"Loss % Std Dev: {evaluation_metrics.loss_percentage_standard_deviation:.2%}\n"
+                f"Loss % Std Dev: {evaluation_metrics.loss_percentage_standard_deviation:.2%}, "
+                f"Mean holding period: {evaluation_metrics.mean_holding_period:.2f} bars, "
+                f"Holding period Std Dev: {evaluation_metrics.holding_period_standard_deviation:.2f} bars\n"
             )
         )
 

--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -18,6 +18,7 @@ class Trade:
     entry_price: float
     exit_price: float
     profit: float
+    holding_period: int
 
 
 @dataclass
@@ -78,6 +79,7 @@ def simulate_trades(
                 )
                 exit_price = float(current_row[price_column_name])
                 profit_value = exit_price - entry_price
+                holding_period_value = row_index - entry_row_index
                 trades.append(
                     Trade(
                         entry_date=data.index[entry_row_index],
@@ -85,6 +87,7 @@ def simulate_trades(
                         entry_price=entry_price,
                         exit_price=exit_price,
                         profit=profit_value,
+                        holding_period=holding_period_value,
                     )
                 )
                 in_position = False

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -29,6 +29,8 @@ class StrategyMetrics:
     profit_percentage_standard_deviation: float
     mean_loss_percentage: float
     loss_percentage_standard_deviation: float
+    mean_holding_period: float
+    holding_period_standard_deviation: float
 
 
 def evaluate_ema_sma_cross_strategy(
@@ -55,11 +57,13 @@ def evaluate_ema_sma_cross_strategy(
     Returns
     -------
     StrategyMetrics
-        Metrics including total trades, win rate, and profit and loss statistics.
+        Metrics including total trades, win rate, profit and loss statistics, and
+        holding period analysis.
     """
     trade_profit_list: List[float] = []
     profit_percentage_list: List[float] = []
     loss_percentage_list: List[float] = []
+    holding_period_list: List[int] = []
     for csv_path in data_directory.glob("*.csv"):
         price_data_frame = pandas.read_csv(
             csv_path, parse_dates=["Date"], index_col="Date"
@@ -147,6 +151,7 @@ def evaluate_ema_sma_cross_strategy(
         )
         for completed_trade in simulation_result.trades:
             trade_profit_list.append(completed_trade.profit)
+            holding_period_list.append(completed_trade.holding_period)
             percentage_change = (
                 completed_trade.profit / completed_trade.entry_price
             )
@@ -164,6 +169,8 @@ def evaluate_ema_sma_cross_strategy(
             profit_percentage_standard_deviation=0.0,
             mean_loss_percentage=0.0,
             loss_percentage_standard_deviation=0.0,
+            mean_holding_period=0.0,
+            holding_period_standard_deviation=0.0,
         )
 
     winning_trade_count = sum(
@@ -182,10 +189,14 @@ def evaluate_ema_sma_cross_strategy(
         win_rate=win_rate,
         mean_profit_percentage=calculate_mean(profit_percentage_list),
         profit_percentage_standard_deviation=calculate_standard_deviation(
-            profit_percentage_list
+        profit_percentage_list
         ),
         mean_loss_percentage=calculate_mean(loss_percentage_list),
         loss_percentage_standard_deviation=calculate_standard_deviation(
             loss_percentage_list
+        ),
+        mean_holding_period=calculate_mean([float(value) for value in holding_period_list]),
+        holding_period_standard_deviation=calculate_standard_deviation(
+            [float(value) for value in holding_period_list]
         ),
     )

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -117,6 +117,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
             profit_percentage_standard_deviation=0.0,
             mean_loss_percentage=0.05,
             loss_percentage_standard_deviation=0.0,
+            mean_holding_period=2.0,
+            holding_period_standard_deviation=1.0,
         )
 
     monkeypatch.setattr(
@@ -131,5 +133,6 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     assert call_record["called"] is True
     assert (
         "Trades: 3, Win rate: 50.00%, Mean profit %: 10.00%, Profit % Std Dev: 0.00%, "
-        "Mean loss %: 5.00%, Loss % Std Dev: 0.00%" in output_buffer.getvalue()
+        "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "
+        "Holding period Std Dev: 1.00 bars" in output_buffer.getvalue()
     )

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -36,6 +36,7 @@ def test_simulate_trades_executes_trade_flow_with_default_column() -> None:
     assert completed_trade.entry_price == 102.0
     assert completed_trade.exit_price == 106.0
     assert completed_trade.profit == 4.0
+    assert completed_trade.holding_period == 3
     assert result.total_profit == 4.0
 
 
@@ -82,6 +83,7 @@ def test_simulate_trades_with_sma_strategy_uses_aligned_labels() -> None:
     assert completed_trade.entry_price == 102.0
     assert completed_trade.exit_price == 103.0
     assert completed_trade.profit == 1.0
+    assert completed_trade.holding_period == 2
     assert result.total_profit == 1.0
 
 
@@ -114,4 +116,5 @@ def test_simulate_trades_handles_distinct_entry_and_exit_price_columns() -> None
     assert completed_trade.entry_price == 10.0
     assert completed_trade.exit_price == 13.0
     assert completed_trade.profit == 3.0
+    assert completed_trade.holding_period == 1
     assert result.total_profit == 3.0

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -285,6 +285,7 @@ def test_evaluate_ema_sma_cross_strategy_computes_profit_and_loss_statistics(
             entry_price=10.0,
             exit_price=12.0,
             profit=2.0,
+            holding_period=1,
         ),
         Trade(
             entry_date=date_index[2],
@@ -292,6 +293,7 @@ def test_evaluate_ema_sma_cross_strategy_computes_profit_and_loss_statistics(
             entry_price=10.0,
             exit_price=9.0,
             profit=-1.0,
+            holding_period=1,
         ),
     ]
     simulation_result = SimulationResult(trades=trades, total_profit=1.0)
@@ -309,3 +311,5 @@ def test_evaluate_ema_sma_cross_strategy_computes_profit_and_loss_statistics(
     assert result.profit_percentage_standard_deviation == 0.0
     assert result.mean_loss_percentage == pytest.approx(0.1)
     assert result.loss_percentage_standard_deviation == 0.0
+    assert result.mean_holding_period == pytest.approx(1.0)
+    assert result.holding_period_standard_deviation == 0.0


### PR DESCRIPTION
## Summary
- Track holding period for each trade during simulation
- Include holding period mean and standard deviation in strategy evaluation and CLI output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a94ae91e40832ba39dc8b34b00d5d4