### PR TITLE
Add combined strategy evaluator and shell integration

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -117,13 +117,13 @@ class StockShell(cmd.Cmd):
             return
         buy_strategy_name, sell_strategy_name = argument_parts
         if (
-            buy_strategy_name != "ema_sma_cross"
-            or sell_strategy_name != "ema_sma_cross"
+            buy_strategy_name not in strategy.SUPPORTED_STRATEGIES
+            or sell_strategy_name not in strategy.SUPPORTED_STRATEGIES
         ):
             self.stdout.write("unsupported strategies\n")
             return
-        evaluation_metrics = strategy.evaluate_ema_sma_cross_strategy(
-            DATA_DIRECTORY
+        evaluation_metrics = strategy.evaluate_combined_strategy(
+            DATA_DIRECTORY, buy_strategy_name, sell_strategy_name
         )
         self.stdout.write(
             (
@@ -141,13 +141,15 @@ class StockShell(cmd.Cmd):
     # TODO: review
     def help_start_simulate(self) -> None:
         """Display help for the start_simulate command."""
+        available_strategies = ", ".join(strategy.SUPPORTED_STRATEGIES.keys())
         self.stdout.write(
             "start_simulate BUY_STRATEGY SELL_STRATEGY\n"
             "Evaluate trading strategies using cached data.\n"
             "Parameters:\n"
             "  BUY_STRATEGY: Name of the buying strategy.\n"
             "  SELL_STRATEGY: Name of the selling strategy.\n"
-            "Currently only 'ema_sma_cross' is supported for both parameters.\n"
+            f"Available strategies: {available_strategies}.\n"
+            "Buy and sell strategies may differ.\n"
         )
 
     def do_exit(self, argument_line: str) -> bool:  # noqa: D401

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from statistics import mean, stdev
-from typing import List
+from typing import Callable, Dict, List
 
 import re
 import pandas
@@ -31,6 +31,236 @@ class StrategyMetrics:
     loss_percentage_standard_deviation: float
     mean_holding_period: float
     holding_period_standard_deviation: float
+
+
+def load_price_data(csv_file_path: Path) -> pandas.DataFrame:
+    """Load price data from ``csv_file_path`` and normalize column names."""
+    # TODO: review
+
+    price_data_frame = pandas.read_csv(
+        csv_file_path, parse_dates=["Date"], index_col="Date"
+    )
+    if isinstance(price_data_frame.columns, pandas.MultiIndex):
+        price_data_frame.columns = price_data_frame.columns.get_level_values(0)
+    price_data_frame.columns = [
+        re.sub(r"[^a-z0-9]+", "_", str(column_name).strip().lower())
+        for column_name in price_data_frame.columns
+    ]
+    price_data_frame.columns = [
+        re.sub(
+            r"^_+",
+            "",
+            re.sub(
+                r"(?:^|_)(open|close|high|low|volume)_.*",
+                r"\1",
+                column_name,
+            ),
+        )
+        for column_name in price_data_frame.columns
+    ]
+    required_columns = {"open", "close"}
+    missing_column_names = [
+        required_column
+        for required_column in required_columns
+        if required_column not in price_data_frame.columns
+    ]
+    if missing_column_names:
+        missing_columns_string = ", ".join(missing_column_names)
+        raise ValueError(
+            f"Missing required columns: {missing_columns_string} in file {csv_file_path.name}"
+        )
+    return price_data_frame
+
+
+def attach_ema_sma_cross_signals(
+    price_data_frame: pandas.DataFrame, window_size: int = 15
+) -> None:
+    """Attach EMA/SMA cross entry and exit signals to ``price_data_frame``."""
+    # TODO: review
+
+    price_data_frame["ema_value"] = ema(price_data_frame["close"], window_size)
+    price_data_frame["sma_value"] = sma(price_data_frame["close"], window_size)
+    price_data_frame["long_term_sma_value"] = sma(
+        price_data_frame["close"], LONG_TERM_SMA_WINDOW
+    )
+    price_data_frame["ema_previous"] = price_data_frame["ema_value"].shift(1)
+    price_data_frame["sma_previous"] = price_data_frame["sma_value"].shift(1)
+    price_data_frame["long_term_sma_previous"] = price_data_frame[
+        "long_term_sma_value"
+    ].shift(1)
+    price_data_frame["close_previous"] = price_data_frame["close"].shift(1)
+    ema_cross_up = (
+        (price_data_frame["ema_previous"] <= price_data_frame["sma_previous"])
+        & (price_data_frame["ema_value"] > price_data_frame["sma_value"])
+    )
+    ema_cross_down = (
+        (price_data_frame["ema_previous"] >= price_data_frame["sma_previous"])
+        & (price_data_frame["ema_value"] < price_data_frame["sma_value"])
+    )
+    price_data_frame["ema_sma_cross_entry_signal"] = (
+        ema_cross_up.shift(1, fill_value=False)
+        & (
+            price_data_frame["close_previous"]
+            > price_data_frame["long_term_sma_previous"]
+        )
+    )
+    price_data_frame["ema_sma_cross_exit_signal"] = ema_cross_down.shift(
+        1, fill_value=False
+    )
+
+
+def attach_kalman_filtering_signals(
+    price_data_frame: pandas.DataFrame,
+    process_variance: float = 1e-5,
+    observation_variance: float = 1.0,
+) -> None:
+    """Attach Kalman filtering breakout signals to ``price_data_frame``."""
+    # TODO: review
+
+    kalman_data_frame = kalman_filter(
+        price_data_frame["close"], process_variance, observation_variance
+    )
+    price_data_frame["kalman_estimate"] = kalman_data_frame["estimate"]
+    price_data_frame["kalman_upper"] = kalman_data_frame["upper_bound"]
+    price_data_frame["kalman_lower"] = kalman_data_frame["lower_bound"]
+    price_data_frame["close_previous"] = price_data_frame["close"].shift(1)
+    price_data_frame["upper_previous"] = price_data_frame["kalman_upper"].shift(1)
+    price_data_frame["lower_previous"] = price_data_frame["kalman_lower"].shift(1)
+    breaks_upper = (
+        (price_data_frame["close_previous"] <= price_data_frame["upper_previous"])
+        & (price_data_frame["close"] > price_data_frame["kalman_upper"])
+    )
+    breaks_lower = (
+        (price_data_frame["close_previous"] >= price_data_frame["lower_previous"])
+        & (price_data_frame["close"] < price_data_frame["kalman_lower"])
+    )
+    price_data_frame["kalman_filtering_entry_signal"] = breaks_upper.shift(
+        1, fill_value=False
+    )
+    price_data_frame["kalman_filtering_exit_signal"] = breaks_lower.shift(
+        1, fill_value=False
+    )
+
+
+SUPPORTED_STRATEGIES: Dict[str, Callable[[pandas.DataFrame], None]] = {
+    "ema_sma_cross": attach_ema_sma_cross_signals,
+    "kalman_filtering": attach_kalman_filtering_signals,
+}
+
+
+def calculate_metrics(
+    trade_profit_list: List[float],
+    profit_percentage_list: List[float],
+    loss_percentage_list: List[float],
+    holding_period_list: List[int],
+) -> StrategyMetrics:
+    """Compute summary metrics for a list of simulated trades."""
+    # TODO: review
+
+    total_trades = len(trade_profit_list)
+    if total_trades == 0:
+        return StrategyMetrics(
+            total_trades=0,
+            win_rate=0.0,
+            mean_profit_percentage=0.0,
+            profit_percentage_standard_deviation=0.0,
+            mean_loss_percentage=0.0,
+            loss_percentage_standard_deviation=0.0,
+            mean_holding_period=0.0,
+            holding_period_standard_deviation=0.0,
+        )
+
+    winning_trade_count = sum(
+        1 for profit_amount in trade_profit_list if profit_amount > 0
+    )
+    win_rate = winning_trade_count / total_trades
+
+    def calculate_mean(values: List[float]) -> float:
+        return mean(values) if values else 0.0
+
+    def calculate_standard_deviation(values: List[float]) -> float:
+        return stdev(values) if len(values) > 1 else 0.0
+
+    return StrategyMetrics(
+        total_trades=total_trades,
+        win_rate=win_rate,
+        mean_profit_percentage=calculate_mean(profit_percentage_list),
+        profit_percentage_standard_deviation=calculate_standard_deviation(
+            profit_percentage_list
+        ),
+        mean_loss_percentage=calculate_mean(loss_percentage_list),
+        loss_percentage_standard_deviation=calculate_standard_deviation(
+            loss_percentage_list
+        ),
+        mean_holding_period=calculate_mean(
+            [float(value) for value in holding_period_list]
+        ),
+        holding_period_standard_deviation=calculate_standard_deviation(
+            [float(value) for value in holding_period_list]
+        ),
+    )
+
+
+def evaluate_combined_strategy(
+    data_directory: Path,
+    buy_strategy_name: str,
+    sell_strategy_name: str,
+) -> StrategyMetrics:
+    """Evaluate a combination of strategies for entry and exit signals."""
+    # TODO: review
+
+    if buy_strategy_name not in SUPPORTED_STRATEGIES:
+        raise ValueError(f"Unsupported strategy: {buy_strategy_name}")
+    if sell_strategy_name not in SUPPORTED_STRATEGIES:
+        raise ValueError(f"Unsupported strategy: {sell_strategy_name}")
+
+    trade_profit_list: List[float] = []
+    profit_percentage_list: List[float] = []
+    loss_percentage_list: List[float] = []
+    holding_period_list: List[int] = []
+
+    for csv_file_path in data_directory.glob("*.csv"):
+        price_data_frame = load_price_data(csv_file_path)
+        SUPPORTED_STRATEGIES[buy_strategy_name](price_data_frame)
+        if buy_strategy_name != sell_strategy_name:
+            SUPPORTED_STRATEGIES[sell_strategy_name](price_data_frame)
+
+        def entry_rule(current_row: pandas.Series) -> bool:
+            return bool(
+                current_row[f"{buy_strategy_name}_entry_signal"]
+            )
+
+        def exit_rule(
+            current_row: pandas.Series, entry_row: pandas.Series
+        ) -> bool:
+            return bool(
+                current_row[f"{sell_strategy_name}_exit_signal"]
+            )
+
+        simulation_result = simulate_trades(
+            data=price_data_frame,
+            entry_rule=entry_rule,
+            exit_rule=exit_rule,
+            entry_price_column="open",
+            exit_price_column="open",
+        )
+        for completed_trade in simulation_result.trades:
+            trade_profit_list.append(completed_trade.profit)
+            holding_period_list.append(completed_trade.holding_period)
+            percentage_change = (
+                completed_trade.profit / completed_trade.entry_price
+            )
+            if percentage_change > 0:
+                profit_percentage_list.append(percentage_change)
+            elif percentage_change < 0:
+                loss_percentage_list.append(abs(percentage_change))
+
+    return calculate_metrics(
+        trade_profit_list,
+        profit_percentage_list,
+        loss_percentage_list,
+        holding_period_list,
+    )
 
 
 def evaluate_ema_sma_cross_strategy(


### PR DESCRIPTION
## Summary
- add signal helpers and a combined evaluator to mix EMA/SMA cross with Kalman strategies
- teach the shell to validate strategy names and invoke the combined evaluator
- extend tests for mixed strategies and unsupported names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a9576e686c832b8cc004bf0a3e80ab