### PR TITLE
Handle empty data in combined strategy

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -236,12 +236,16 @@ def evaluate_combined_strategy(
 
     for csv_file_path in data_directory.glob("*.csv"):
         price_data_frame = load_price_data(csv_file_path)
+        if price_data_frame.empty:
+            continue
         if minimum_average_dollar_volume is not None:
             if "volume" not in price_data_frame.columns:
                 raise ValueError(
                     "Volume column is required to compute dollar volume filter"
                 )
             dollar_volume_series = price_data_frame["close"] * price_data_frame["volume"]
+            if dollar_volume_series.empty:
+                continue
             recent_average_dollar_volume = (
                 dollar_volume_series.rolling(window=50).mean().iloc[-1] / 1_000_000
             )

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -446,3 +446,20 @@ def test_evaluate_combined_strategy_dollar_volume_filter(
         minimum_average_dollar_volume=5,
     )
     assert simulate_called["called"] is True
+
+
+def test_evaluate_combined_strategy_handles_empty_csv(tmp_path: Path) -> None:
+    """evaluate_combined_strategy should skip empty CSV files and return zero trades."""
+    empty_data_frame = pandas.DataFrame(
+        columns=["Date", "open", "close", "volume"]
+    )
+    csv_file_path = tmp_path / "empty.csv"
+    empty_data_frame.to_csv(csv_file_path, index=False)
+
+    result = evaluate_combined_strategy(
+        tmp_path,
+        "ema_sma_cross",
+        "ema_sma_cross",
+    )
+
+    assert result.total_trades == 0


### PR DESCRIPTION
## Summary
- Skip CSV files with no price data before strategy evaluation
- Guard against empty dollar volume series when applying volume filter
- Test combined strategy handles empty CSV without trades or errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a9e580b85c832bb12f2aebe078604e