### PR TITLE
feat: report market concurrency

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -143,7 +143,8 @@ class StockShell(cmd.Cmd):
                 f"Mean loss %: {evaluation_metrics.mean_loss_percentage:.2%}, "
                 f"Loss % Std Dev: {evaluation_metrics.loss_percentage_standard_deviation:.2%}, "
                 f"Mean holding period: {evaluation_metrics.mean_holding_period:.2f} bars, "
-                f"Holding period Std Dev: {evaluation_metrics.holding_period_standard_deviation:.2f} bars\n"
+                f"Holding period Std Dev: {evaluation_metrics.holding_period_standard_deviation:.2f} bars, "
+                f"Max concurrent positions: {evaluation_metrics.maximum_concurrent_positions}\n"
             )
         )
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -126,6 +126,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
             loss_percentage_standard_deviation=0.0,
             mean_holding_period=2.0,
             holding_period_standard_deviation=1.0,
+            maximum_concurrent_positions=2,
         )
 
     monkeypatch.setattr(
@@ -142,7 +143,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     assert (
         "Trades: 3, Win rate: 50.00%, Mean profit %: 10.00%, Profit % Std Dev: 0.00%, "
         "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "
-        "Holding period Std Dev: 1.00 bars" in output_buffer.getvalue()
+        "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2" in output_buffer.getvalue()
     )
 
 
@@ -172,6 +173,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
             loss_percentage_standard_deviation=0.0,
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
+            maximum_concurrent_positions=0,
         )
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- surface maximum concurrent positions in strategy metrics and CLI output
- compute market-wide concurrency during combined strategy evaluation
- test concurrency reporting and CLI output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a9f12f8bd8832bbed7e41a4b3777f7