### PR TITLE
Add portfolio cash simulation and final balance reporting

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -144,7 +144,8 @@ class StockShell(cmd.Cmd):
                 f"Loss % Std Dev: {evaluation_metrics.loss_percentage_standard_deviation:.2%}, "
                 f"Mean holding period: {evaluation_metrics.mean_holding_period:.2f} bars, "
                 f"Holding period Std Dev: {evaluation_metrics.holding_period_standard_deviation:.2f} bars, "
-                f"Max concurrent positions: {evaluation_metrics.maximum_concurrent_positions}\n"
+                f"Max concurrent positions: {evaluation_metrics.maximum_concurrent_positions}, "
+                f"Final balance: {evaluation_metrics.final_balance:.2f}\n"
             )
         )
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -127,6 +127,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
             mean_holding_period=2.0,
             holding_period_standard_deviation=1.0,
             maximum_concurrent_positions=2,
+            final_balance=123.45,
         )
 
     monkeypatch.setattr(
@@ -143,7 +144,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     assert (
         "Trades: 3, Win rate: 50.00%, Mean profit %: 10.00%, Profit % Std Dev: 0.00%, "
         "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "
-        "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2" in output_buffer.getvalue()
+        "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2, Final balance: 123.45" in output_buffer.getvalue()
     )
 
 
@@ -174,6 +175,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            final_balance=0.0,
         )
 
     monkeypatch.setattr(
@@ -220,6 +222,7 @@ def test_start_simulate_supports_rsi_strategy(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            final_balance=0.0,
         )
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- simulate capital allocation across trades and track final cash
- include final portfolio balance in strategy metrics and CLI output
- close open positions using last price for accurate results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68aa0dae87d4832b83f90764676eff06