### PR TITLE
Apply trade commission and lower starting cash

### DIFF
--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -8,6 +8,8 @@ from typing import Callable, Iterable, List
 
 import pandas
 
+# TODO: review
+TRADE_COMMISSION: float = 1.0
 
 @dataclass(frozen=True)
 class Trade:
@@ -52,6 +54,8 @@ def simulate_trades(
     exit_price_column: str, optional
         Column name used for calculating exit price. When ``None``,
         ``entry_price_column`` is used for both entry and exit prices.
+    A fixed commission defined by ``TRADE_COMMISSION`` is subtracted from each
+    trade's profit.
 
     Returns
     -------
@@ -81,7 +85,7 @@ def simulate_trades(
                     exit_price_column if exit_price_column is not None else entry_price_column
                 )
                 exit_price = float(current_row[price_column_name])
-                profit_value = exit_price - entry_price
+                profit_value = exit_price - entry_price - TRADE_COMMISSION
                 holding_period_value = row_index - entry_row_index
                 trades.append(
                     Trade(
@@ -104,7 +108,7 @@ def simulate_trades(
         final_row = data.iloc[-1]
         entry_price = float(entry_row[entry_price_column])
         exit_price = float(final_row[price_column_name])
-        profit_value = exit_price - entry_price
+        profit_value = exit_price - entry_price - TRADE_COMMISSION
         holding_period_value = len(data) - entry_row_index - 1
         trades.append(
             Trade(
@@ -165,6 +169,7 @@ def simulate_portfolio_balance(
         Initial cash available for trading.
     maximum_positions : int
         Maximum number of concurrent positions allowed.
+    Each trade closure deducts ``TRADE_COMMISSION`` from the cash balance.
 
     Returns
     -------
@@ -185,6 +190,7 @@ def simulate_portfolio_balance(
                 cash_balance += invested_amount * (
                     trade.exit_price / trade.entry_price
                 )
+                cash_balance -= TRADE_COMMISSION
         else:
             if len(open_trades) >= maximum_positions or cash_balance <= 0:
                 continue

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -242,7 +242,7 @@ def evaluate_combined_strategy(
     buy_strategy_name: str,
     sell_strategy_name: str,
     minimum_average_dollar_volume: float | None = None,
-    starting_cash: float = 10000.0,
+    starting_cash: float = 1000.0,
     maximum_positions: int = 5,
 ) -> StrategyMetrics:
     """Evaluate a combination of strategies for entry and exit signals.
@@ -259,7 +259,7 @@ def evaluate_combined_strategy(
         Minimum 50-day moving average dollar volume, in millions, required for a
         symbol to be included in the evaluation. When ``None``, no filter is
         applied.
-    starting_cash: float, default 10000.0
+    starting_cash: float, default 1000.0
         Initial amount of cash used for portfolio simulation.
     maximum_positions: int, default 5
         Maximum number of concurrent positions during simulation.

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -12,6 +12,7 @@ from stock_indicator.indicators import sma
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from stock_indicator.simulator import (
+    TRADE_COMMISSION,
     SimulationResult,
     Trade,
     calculate_maximum_concurrent_positions,
@@ -42,9 +43,10 @@ def test_simulate_trades_executes_trade_flow_with_default_column() -> None:
     assert completed_trade.exit_date == expected_exit_date
     assert completed_trade.entry_price == 102.0
     assert completed_trade.exit_price == 106.0
-    assert completed_trade.profit == 4.0
+    expected_profit = 4.0 - TRADE_COMMISSION
+    assert completed_trade.profit == expected_profit
     assert completed_trade.holding_period == 3
-    assert result.total_profit == 4.0
+    assert result.total_profit == expected_profit
 
 
 def test_simulate_trades_with_sma_strategy_uses_aligned_labels() -> None:
@@ -89,9 +91,10 @@ def test_simulate_trades_with_sma_strategy_uses_aligned_labels() -> None:
     assert completed_trade.exit_date == expected_exit_date
     assert completed_trade.entry_price == 102.0
     assert completed_trade.exit_price == 103.0
-    assert completed_trade.profit == 1.0
+    expected_profit = 1.0 - TRADE_COMMISSION
+    assert completed_trade.profit == expected_profit
     assert completed_trade.holding_period == 2
-    assert result.total_profit == 1.0
+    assert result.total_profit == expected_profit
 
 
 def test_simulate_trades_handles_distinct_entry_and_exit_price_columns() -> None:
@@ -122,9 +125,10 @@ def test_simulate_trades_handles_distinct_entry_and_exit_price_columns() -> None
     assert completed_trade.exit_date == expected_exit_date
     assert completed_trade.entry_price == 10.0
     assert completed_trade.exit_price == 13.0
-    assert completed_trade.profit == 3.0
+    expected_profit = 3.0 - TRADE_COMMISSION
+    assert completed_trade.profit == expected_profit
     assert completed_trade.holding_period == 1
-    assert result.total_profit == 3.0
+    assert result.total_profit == expected_profit
 
 
 def test_simulate_trades_closes_open_position_at_end() -> None:
@@ -242,4 +246,5 @@ def test_simulate_portfolio_balance_allocates_proportional_cash() -> None:
     final_balance = simulate_portfolio_balance(
         [trade_alpha, trade_beta, trade_gamma], 100.0, 2
     )
-    assert pytest.approx(final_balance, rel=1e-6) == 150.0
+    expected_final_balance = 150.0 - TRADE_COMMISSION * 2
+    assert pytest.approx(final_balance, rel=1e-6) == expected_final_balance


### PR DESCRIPTION
## Summary
- Deduct a fixed $1 commission from every simulated trade and portfolio balance
- Lower default simulation starting cash from $10,000 to $1,000
- Align trade simulation tests with new commission and starting cash

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aa8badf634832b8dec8461a5c1a28f