### PR TITLE
feat: add stop loss support

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -244,6 +244,7 @@ def evaluate_combined_strategy(
     minimum_average_dollar_volume: float | None = None,
     starting_cash: float = 1000.0,
     maximum_positions: int = 5,
+    stop_loss_percentage: float = 1.0,
 ) -> StrategyMetrics:
     """Evaluate a combination of strategies for entry and exit signals.
 
@@ -263,6 +264,10 @@ def evaluate_combined_strategy(
         Initial amount of cash used for portfolio simulation.
     maximum_positions: int, default 5
         Maximum number of concurrent positions during simulation.
+    stop_loss_percentage: float, default 1.0
+        Fractional loss from the entry price that triggers an exit on the next
+        bar's opening price. Values greater than or equal to ``1.0`` disable
+        the stop-loss mechanism.
     """
     # TODO: review
 
@@ -319,6 +324,7 @@ def evaluate_combined_strategy(
             exit_rule=exit_rule,
             entry_price_column="open",
             exit_price_column="open",
+            stop_loss_percentage=stop_loss_percentage,
         )
         simulation_results.append(simulation_result)
         all_trades.extend(simulation_result.trades)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,8 +58,10 @@ def test_run_cli_invokes_components(
         entry_rule: Callable[[pandas.Series], bool],
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
         price_column: str = "close",
+        stop_loss_percentage: float = 1.0,
     ) -> SimulationResult:
         assert price_column == "close"
+        assert stop_loss_percentage == 1.0
         return SimulationResult(trades=[], total_profit=5.0)
 
     monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)
@@ -108,10 +110,12 @@ def test_run_cli_uses_close_by_default(
         entry_rule: Callable[[pandas.Series], bool],
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
         price_column: str = "close",
+        stop_loss_percentage: float = 1.0,
     ) -> SimulationResult:
         assert price_column == "close"
         assert entry_rule(data_frame.iloc[0])
         assert not exit_rule(data_frame.iloc[0], data_frame.iloc[0])
+        assert stop_loss_percentage == 1.0
         return SimulationResult(trades=[], total_profit=0.0)
 
     monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)
@@ -160,10 +164,12 @@ def test_run_cli_accepts_price_column_argument(
         entry_rule: Callable[[pandas.Series], bool],
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
         price_column: str = "close",
+        stop_loss_percentage: float = 1.0,
     ) -> SimulationResult:
         assert price_column == "open"
         assert not entry_rule(data_frame.iloc[0])
         assert exit_rule(data_frame.iloc[0], data_frame.iloc[0])
+        assert stop_loss_percentage == 1.0
         return SimulationResult(trades=[], total_profit=0.0)
 
     monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)


### PR DESCRIPTION
## Summary
- add optional stop loss parameter to `start_simulate`
- support stop-loss handling in trade simulation and strategy evaluation
- test stop-loss workflow and CLI integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aaa3712424832b9cf074861f79e2ec