### PR TITLE
Fix default stop loss to 1.0 when omitted

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -109,7 +109,9 @@ class StockShell(cmd.Cmd):
     # TODO: review
     def do_start_simulate(self, argument_line: str) -> None:  # noqa: D401
         """start_simulate DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]
-        Evaluate trading strategies using cached data."""
+        Evaluate trading strategies using cached data.
+
+        STOP_LOSS defaults to 1.0 when not provided."""
         argument_parts: List[str] = argument_line.split()
         if len(argument_parts) not in (3, 4):
             self.stdout.write(
@@ -124,7 +126,7 @@ class StockShell(cmd.Cmd):
                 self.stdout.write("invalid stop loss\n")
                 return
         else:
-            stop_loss_percentage = 0.075
+            stop_loss_percentage = 1.0
         volume_match = re.fullmatch(r"dollar_volume>(\d+(?:\.\d+)?)", volume_filter)
         if volume_match is None:
             self.stdout.write("unsupported filter\n")
@@ -169,7 +171,8 @@ class StockShell(cmd.Cmd):
             "  DOLLAR_VOLUME_FILTER: Format dollar_volume>NUMBER (in millions).\n"
             "  BUY_STRATEGY: Name of the buying strategy.\n"
             "  SELL_STRATEGY: Name of the selling strategy.\n"
-            "  STOP_LOSS: Fractional loss that triggers an exit on the next day's open.\n"
+            "  STOP_LOSS: Fractional loss that triggers an exit on the next day's open. "
+            "Defaults to 1.0.\n"
             f"Available strategies: {available_strategies}.\n"
             "Buy and sell strategies may differ.\n"
         )

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -144,7 +144,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     shell.onecmd("start_simulate dollar_volume>500 ema_sma_cross ema_sma_cross")
     assert call_record["strategies"] == ("ema_sma_cross", "ema_sma_cross")
     assert volume_record["threshold"] == 500.0
-    assert stop_loss_record["value"] == 0.075
+    assert stop_loss_record["value"] == 1.0
     assert (
         "Trades: 3, Win rate: 50.00%, Mean profit %: 10.00%, Profit % Std Dev: 0.00%, "
         "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "
@@ -198,7 +198,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
         "kalman_filtering",
     )
     assert threshold_record["threshold"] == 0.0
-    assert stop_loss_record["value"] == 0.075
+    assert stop_loss_record["value"] == 1.0
 
 
 def test_start_simulate_supports_rsi_strategy(


### PR DESCRIPTION
## Summary
- Correct start_simulate to default stop loss to 1.0 when no value is supplied
- Document default stop loss in start_simulate help text
- Update tests to expect the new default stop loss

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aaa8097f88832b8c1e93d0c624488f