### PR TITLE
feat: cache stock history downloads

### DIFF
--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -14,8 +14,13 @@ def test_run_daily_tasks_detects_signals(tmp_path, monkeypatch):
     def fake_update_symbol_cache() -> None:
         return None
 
-    def fake_download_history(symbol: str, start: str, end: str) -> pandas.DataFrame:
-        return pandas.DataFrame({"close": [1.0, 2.0, 3.0]})
+    def fake_download_history(
+        symbol: str, start: str, end: str, cache_path: Path | None = None
+    ) -> pandas.DataFrame:
+        frame = pandas.DataFrame({"close": [1.0, 2.0, 3.0]})
+        if cache_path is not None:
+            frame.to_csv(cache_path)
+        return frame
 
     def fake_strategy(price_history_frame: pandas.DataFrame) -> None:
         price_history_frame["fake_strategy_entry_signal"] = [False, False, True]


### PR DESCRIPTION
## Summary
- cache downloaded history data to CSV files and request only missing rows
- pass per-symbol cache paths from daily task runner
- add tests for cached downloads and update cron tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aadc1183c0832bb8d322ddc64f4ed7