### PR TITLE
Display annual returns in simulation output

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -159,6 +159,10 @@ class StockShell(cmd.Cmd):
                 f"Final balance: {evaluation_metrics.final_balance:.2f}\n"
             )
         )
+        for year, annual_return in sorted(
+            evaluation_metrics.annual_returns.items()
+        ):
+            self.stdout.write(f"Year {year}: {annual_return:.2%}\n")
 
     # TODO: review
     def help_start_simulate(self) -> None:

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -131,7 +131,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
             holding_period_standard_deviation=1.0,
             maximum_concurrent_positions=2,
             final_balance=123.45,
-            annual_returns={},
+            annual_returns={2023: 0.1, 2024: -0.05},
         )
 
     monkeypatch.setattr(
@@ -151,6 +151,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "
         "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2, Final balance: 123.45" in output_buffer.getvalue()
     )
+    assert "Year 2023: 10.00%" in output_buffer.getvalue()
+    assert "Year 2024: -5.00%" in output_buffer.getvalue()
 
 
 def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- show annual return percentages after simulation metrics
- test that annual return lines appear in simulation output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab1f61dfa0832b8a24f96f102d4036