### PR TITLE
Remove deprecated FTD EMA/SMA shell command

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -1,0 +1,11 @@
+# Usage
+
+To evaluate the FTD EMA and SMA cross strategy in the management shell, call:
+
+```
+start_simulate dollar_volume>50 ftd_ema_sma_cross ftd_ema_sma_cross
+```
+
+The previous `start_ftd_ema_sma_cross` command has been removed.
+Use `start_simulate` with `ftd_ema_sma_cross` for both the buying and
+selling strategies instead.

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -181,35 +181,6 @@ class StockShell(cmd.Cmd):
             "Buy and sell strategies may differ.\n"
         )
 
-    # TODO: review
-    def do_start_ftd_ema_sma_cross(self, argument_line: str) -> None:  # noqa: D401
-        """start_ftd_ema_sma_cross DOLLAR_VOLUME_FILTER [STOP_LOSS]
-        Evaluate the ftd_ema_sma_cross strategy for both entry and exit."""
-        argument_parts: List[str] = argument_line.split()
-        if len(argument_parts) not in (1, 2):
-            self.stdout.write(
-                "usage: start_ftd_ema_sma_cross DOLLAR_VOLUME_FILTER [STOP_LOSS]\n"
-            )
-            return
-        volume_filter = argument_parts[0]
-        stop_loss_argument = argument_parts[1] if len(argument_parts) == 2 else ""
-        command_arguments = (
-            f"{volume_filter} ftd_ema_sma_cross ftd_ema_sma_cross"
-            f"{(' ' + stop_loss_argument) if stop_loss_argument else ''}"
-        )
-        self.do_start_simulate(command_arguments)
-
-    # TODO: review
-    def help_start_ftd_ema_sma_cross(self) -> None:
-        """Display help for the start_ftd_ema_sma_cross command."""
-        self.stdout.write(
-            "start_ftd_ema_sma_cross DOLLAR_VOLUME_FILTER [STOP_LOSS]\n"
-            "Evaluate the ftd_ema_sma_cross strategy using cached data.\n"
-            "Parameters:\n"
-            "  DOLLAR_VOLUME_FILTER: Format dollar_volume>NUMBER (in millions).\n"
-            "  STOP_LOSS: Fractional loss that triggers an exit on the next day's open. "
-            "Defaults to 1.0.\n"
-        )
 
     def do_exit(self, argument_line: str) -> bool:  # noqa: D401
         """exit

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -309,23 +309,3 @@ def test_start_simulate_unsupported_strategy(monkeypatch: pytest.MonkeyPatch) ->
     shell = manage_module.StockShell(stdout=output_buffer)
     shell.onecmd("start_simulate dollar_volume>0 unknown ema_sma_cross")
     assert "unsupported strategies" in output_buffer.getvalue()
-
-
-def test_start_ftd_ema_sma_cross(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The command should evaluate the FTD EMA/SMA cross strategy."""
-    import stock_indicator.manage as manage_module
-
-    recorded_argument: dict[str, str] = {}
-
-    def fake_start_simulate(self: manage_module.StockShell, argument_line: str) -> None:
-        recorded_argument["argument_line"] = argument_line
-
-    monkeypatch.setattr(
-        manage_module.StockShell, "do_start_simulate", fake_start_simulate
-    )
-
-    shell = manage_module.StockShell(stdout=io.StringIO())
-    shell.onecmd("start_ftd_ema_sma_cross dollar_volume>50 0.7")
-    assert recorded_argument["argument_line"] == (
-        "dollar_volume>50 ftd_ema_sma_cross ftd_ema_sma_cross 0.7"
-    )


### PR DESCRIPTION
## Summary
- drop the `start_ftd_ema_sma_cross` command from the management shell
- remove its unit test
- document running the FTD EMA/SMA cross strategy via `start_simulate`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab36d5ec90832b9cdf96e977cda2a6