### PR TITLE
Clarify buy and sell strategy availability

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -9,3 +9,17 @@ start_simulate dollar_volume>50 ftd_ema_sma_cross ftd_ema_sma_cross
 The previous `start_ftd_ema_sma_cross` command has been removed.
 Use `start_simulate` with `ftd_ema_sma_cross` for both the buying and
 selling strategies instead.
+
+## Available strategies
+
+The `start_simulate` command accepts the following strategies:
+
+* `ema_sma_cross`
+* `ema_sma_cross_and_rsi`
+* `ftd_ema_sma_cross`
+* `ema_sma_cross_with_slope`
+* `kalman_filtering` *(sell only)*
+
+Not every strategy supports both buying and selling. Only the first four
+strategies in the list can be used for buying. All five strategies can be used
+for selling.

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -133,8 +133,8 @@ class StockShell(cmd.Cmd):
             return
         minimum_average_dollar_volume = float(volume_match.group(1))
         if (
-            buy_strategy_name not in strategy.SUPPORTED_STRATEGIES
-            or sell_strategy_name not in strategy.SUPPORTED_STRATEGIES
+            buy_strategy_name not in strategy.BUY_STRATEGIES
+            or sell_strategy_name not in strategy.SELL_STRATEGIES
         ):
             self.stdout.write("unsupported strategies\n")
             return
@@ -167,7 +167,8 @@ class StockShell(cmd.Cmd):
     # TODO: review
     def help_start_simulate(self) -> None:
         """Display help for the start_simulate command."""
-        available_strategies = ", ".join(strategy.SUPPORTED_STRATEGIES.keys())
+        available_buy = ", ".join(strategy.BUY_STRATEGIES.keys())
+        available_sell = ", ".join(strategy.SELL_STRATEGIES.keys())
         self.stdout.write(
             "start_simulate DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]\n"
             "Evaluate trading strategies using cached data.\n"
@@ -177,8 +178,8 @@ class StockShell(cmd.Cmd):
             "  SELL_STRATEGY: Name of the selling strategy.\n"
             "  STOP_LOSS: Fractional loss that triggers an exit on the next day's open. "
             "Defaults to 1.0.\n"
-            f"Available strategies: {available_strategies}.\n"
-            "Buy and sell strategies may differ.\n"
+            f"Available buy strategies: {available_buy}.\n"
+            f"Available sell strategies: {available_sell}.\n"
         )
 
 

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -221,13 +221,23 @@ def attach_kalman_filtering_signals(
         1, fill_value=False
     )
 
-
-SUPPORTED_STRATEGIES: Dict[str, Callable[[pandas.DataFrame], None]] = {
+# TODO: review
+BUY_STRATEGIES: Dict[str, Callable[[pandas.DataFrame], None]] = {
     "ema_sma_cross": attach_ema_sma_cross_signals,
     "ema_sma_cross_and_rsi": attach_ema_sma_cross_and_rsi_signals,
     "ftd_ema_sma_cross": attach_ftd_ema_sma_cross_signals,
     "ema_sma_cross_with_slope": attach_ema_sma_cross_with_slope_signals,
+}
+
+# TODO: review
+SELL_STRATEGIES: Dict[str, Callable[[pandas.DataFrame], None]] = {
+    **BUY_STRATEGIES,
     "kalman_filtering": attach_kalman_filtering_signals,
+}
+
+# TODO: review
+SUPPORTED_STRATEGIES: Dict[str, Callable[[pandas.DataFrame], None]] = {
+    **SELL_STRATEGIES,
 }
 
 
@@ -327,9 +337,9 @@ def evaluate_combined_strategy(
     """
     # TODO: review
 
-    if buy_strategy_name not in SUPPORTED_STRATEGIES:
+    if buy_strategy_name not in BUY_STRATEGIES:
         raise ValueError(f"Unsupported strategy: {buy_strategy_name}")
-    if sell_strategy_name not in SUPPORTED_STRATEGIES:
+    if sell_strategy_name not in SELL_STRATEGIES:
         raise ValueError(f"Unsupported strategy: {sell_strategy_name}")
 
     trade_profit_list: List[float] = []
@@ -358,9 +368,9 @@ def evaluate_combined_strategy(
                 recent_average_dollar_volume < minimum_average_dollar_volume
             ):
                 continue
-        SUPPORTED_STRATEGIES[buy_strategy_name](price_data_frame)
+        BUY_STRATEGIES[buy_strategy_name](price_data_frame)
         if buy_strategy_name != sell_strategy_name:
-            SUPPORTED_STRATEGIES[sell_strategy_name](price_data_frame)
+            SELL_STRATEGIES[sell_strategy_name](price_data_frame)
 
         def entry_rule(current_row: pandas.Series) -> bool:
             return bool(

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -360,3 +360,15 @@ def test_start_simulate_unsupported_strategy(monkeypatch: pytest.MonkeyPatch) ->
     shell = manage_module.StockShell(stdout=output_buffer)
     shell.onecmd("start_simulate dollar_volume>0 unknown ema_sma_cross")
     assert "unsupported strategies" in output_buffer.getvalue()
+
+
+def test_start_simulate_rejects_sell_only_buy_strategy() -> None:
+    """The command should reject strategies that are sell only when used for buying."""
+    import stock_indicator.manage as manage_module
+
+    output_buffer = io.StringIO()
+    shell = manage_module.StockShell(stdout=output_buffer)
+    shell.onecmd(
+        "start_simulate dollar_volume>0 kalman_filtering ema_sma_cross"
+    )
+    assert "unsupported strategies" in output_buffer.getvalue()

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -402,6 +402,12 @@ def test_evaluate_combined_strategy_unsupported_name(tmp_path: Path) -> None:
         evaluate_combined_strategy(tmp_path, "unknown", "ema_sma_cross")
 
 
+def test_evaluate_combined_strategy_rejects_sell_only_buy(tmp_path: Path) -> None:
+    """evaluate_combined_strategy should reject sell-only strategies used for buying."""
+    with pytest.raises(ValueError, match="Unsupported strategy"):
+        evaluate_combined_strategy(tmp_path, "kalman_filtering", "ema_sma_cross")
+
+
 def test_evaluate_combined_strategy_dollar_volume_filter(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -481,6 +487,8 @@ def test_evaluate_combined_strategy_reports_maximum_positions(
             }
         ).to_csv(tmp_path / f"{symbol_name}.csv", index=False)
 
+    monkeypatch.setattr(strategy_module, "BUY_STRATEGIES", {"noop": lambda df: None})
+    monkeypatch.setattr(strategy_module, "SELL_STRATEGIES", {"noop": lambda df: None})
     monkeypatch.setattr(strategy_module, "SUPPORTED_STRATEGIES", {"noop": lambda df: None})
 
     simulation_results = [


### PR DESCRIPTION
## Summary
- Distinguish buy and sell strategies in the strategy module
- Validate strategy roles in the management shell and update help text
- Document available strategies and note sell-only options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab3d1707f8832b998e199cccf00044