### PR TITLE
Add annual trade count reporting

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -162,7 +162,10 @@ class StockShell(cmd.Cmd):
         for year, annual_return in sorted(
             evaluation_metrics.annual_returns.items()
         ):
-            self.stdout.write(f"Year {year}: {annual_return:.2%}\n")
+            trade_count = evaluation_metrics.annual_trade_counts.get(year, 0)
+            self.stdout.write(
+                f"Year {year}: {annual_return:.2%}, trade: {trade_count}\n"
+            )
 
     # TODO: review
     def help_start_simulate(self) -> None:

--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -315,3 +315,26 @@ def calculate_annual_returns(
             )
 
     return annual_returns
+
+
+def calculate_annual_trade_counts(trades: Iterable[Trade]) -> Dict[int, int]:
+    """Count completed trades for each calendar year.
+
+    Parameters
+    ----------
+    trades:
+        Collection of trades containing exit dates.
+
+    Returns
+    -------
+    Dict[int, int]
+        Mapping of year to number of trades that closed during that year.
+    """
+    trade_counts: Dict[int, int] = {}
+    for completed_trade in trades:
+        year_value = completed_trade.exit_date.year
+        if year_value in trade_counts:
+            trade_counts[year_value] += 1
+        else:
+            trade_counts[year_value] = 1
+    return trade_counts

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -15,6 +15,7 @@ from .indicators import ema, kalman_filter, sma, rsi, ftd
 from .simulator import (
     calculate_maximum_concurrent_positions,
     calculate_annual_returns,
+    calculate_annual_trade_counts,
     simulate_trades,
     SimulationResult,
     simulate_portfolio_balance,
@@ -41,6 +42,7 @@ class StrategyMetrics:
     maximum_concurrent_positions: int
     final_balance: float
     annual_returns: Dict[int, float]
+    annual_trade_counts: Dict[int, int]
 
 
 def load_price_data(csv_file_path: Path) -> pandas.DataFrame:
@@ -186,7 +188,7 @@ def attach_ftd_ema_sma_cross_signals(
 def attach_ema_sma_cross_with_slope_signals(
     price_data_frame: pandas.DataFrame,
     window_size: int = 50,
-    slope_range: tuple[float, float] = (-0.3, 1.0),
+    slope_range: tuple[float, float] = (-0.3, 0.3),
 ) -> None:
     """Attach EMA/SMA cross signals filtered by SMA slope to ``price_data_frame``.
 
@@ -198,7 +200,7 @@ def attach_ema_sma_cross_with_slope_signals(
     attach_ema_sma_cross_signals(
         price_data_frame,
         window_size,
-        require_close_above_long_term_sma=True,
+        require_close_above_long_term_sma=False,
     )
     price_data_frame["sma_slope"] = (
         price_data_frame["sma_value"] - price_data_frame["sma_previous"]
@@ -305,6 +307,7 @@ def calculate_metrics(
     maximum_concurrent_positions: int = 0,
     final_balance: float = 0.0,
     annual_returns: Dict[int, float] | None = None,
+    annual_trade_counts: Dict[int, int] | None = None,
 ) -> StrategyMetrics:
     """Compute summary metrics for a list of simulated trades."""
     # TODO: review
@@ -323,6 +326,7 @@ def calculate_metrics(
             maximum_concurrent_positions=maximum_concurrent_positions,
             final_balance=final_balance,
             annual_returns={} if annual_returns is None else annual_returns,
+            annual_trade_counts={} if annual_trade_counts is None else annual_trade_counts,
         )
 
     winning_trade_count = sum(
@@ -356,6 +360,7 @@ def calculate_metrics(
         maximum_concurrent_positions=maximum_concurrent_positions,
         final_balance=final_balance,
         annual_returns={} if annual_returns is None else annual_returns,
+        annual_trade_counts={} if annual_trade_counts is None else annual_trade_counts,
     )
 
 
@@ -467,6 +472,7 @@ def evaluate_combined_strategy(
     annual_returns = calculate_annual_returns(
         all_trades, starting_cash, maximum_positions
     )
+    annual_trade_counts = calculate_annual_trade_counts(all_trades)
     final_balance = simulate_portfolio_balance(
         all_trades, starting_cash, maximum_positions
     )
@@ -478,6 +484,7 @@ def evaluate_combined_strategy(
         maximum_concurrent_positions,
         final_balance,
         annual_returns,
+        annual_trade_counts,
     )
 
 
@@ -627,6 +634,7 @@ def evaluate_ema_sma_cross_strategy(
             maximum_concurrent_positions=maximum_concurrent_positions,
             final_balance=0.0,
             annual_returns={},
+            annual_trade_counts={},
         )
 
     winning_trade_count = sum(
@@ -658,6 +666,7 @@ def evaluate_ema_sma_cross_strategy(
         maximum_concurrent_positions=maximum_concurrent_positions,
         final_balance=0.0,
         annual_returns={},
+        annual_trade_counts={},
     )
 
 
@@ -800,6 +809,7 @@ def evaluate_kalman_channel_strategy(
             maximum_concurrent_positions=maximum_concurrent_positions,
             final_balance=0.0,
             annual_returns={},
+            annual_trade_counts={},
         )
 
     winning_trade_count = sum(
@@ -833,4 +843,5 @@ def evaluate_kalman_channel_strategy(
         maximum_concurrent_positions=maximum_concurrent_positions,
         final_balance=0.0,
         annual_returns={},
+        annual_trade_counts={},
     )

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -132,6 +132,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
             maximum_concurrent_positions=2,
             final_balance=123.45,
             annual_returns={2023: 0.1, 2024: -0.05},
+            annual_trade_counts={2023: 2, 2024: 1},
         )
 
     monkeypatch.setattr(
@@ -151,8 +152,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "
         "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2, Final balance: 123.45" in output_buffer.getvalue()
     )
-    assert "Year 2023: 10.00%" in output_buffer.getvalue()
-    assert "Year 2024: -5.00%" in output_buffer.getvalue()
+    assert "Year 2023: 10.00%, trade: 2" in output_buffer.getvalue()
+    assert "Year 2024: -5.00%, trade: 1" in output_buffer.getvalue()
 
 
 def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -187,6 +188,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
             maximum_concurrent_positions=0,
             final_balance=0.0,
             annual_returns={},
+            annual_trade_counts={},
         )
 
     monkeypatch.setattr(
@@ -237,6 +239,7 @@ def test_start_simulate_supports_rsi_strategy(
             maximum_concurrent_positions=0,
             final_balance=0.0,
             annual_returns={},
+            annual_trade_counts={},
         )
 
     monkeypatch.setattr(
@@ -288,6 +291,7 @@ def test_start_simulate_supports_slope_strategy(
             maximum_concurrent_positions=0,
             final_balance=0.0,
             annual_returns={},
+            annual_trade_counts={},
         )
 
     monkeypatch.setattr(
@@ -337,6 +341,7 @@ def test_start_simulate_accepts_stop_loss_argument(
             maximum_concurrent_positions=0,
             final_balance=0.0,
             annual_returns={},
+            annual_trade_counts={},
         )
 
     monkeypatch.setattr(

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -17,6 +17,7 @@ from stock_indicator.simulator import (
     Trade,
     calculate_maximum_concurrent_positions,
     calculate_annual_returns,
+    calculate_annual_trade_counts,
     simulate_trades,
     simulate_portfolio_balance,
 )
@@ -311,3 +312,34 @@ def test_calculate_annual_returns_computes_yearly_returns() -> None:
     expected_return_2024 = (second_year_end - first_year_end) / first_year_end
     assert pytest.approx(annual_returns[2023], rel=1e-6) == expected_return_2023
     assert pytest.approx(annual_returns[2024], rel=1e-6) == expected_return_2024
+
+
+def test_calculate_annual_trade_counts_counts_trades_per_year() -> None:
+    trade_alpha = Trade(
+        entry_date=pandas.Timestamp("2023-01-01"),
+        exit_date=pandas.Timestamp("2023-02-01"),
+        entry_price=10.0,
+        exit_price=11.0,
+        profit=1.0 - TRADE_COMMISSION,
+        holding_period=1,
+    )
+    trade_beta = Trade(
+        entry_date=pandas.Timestamp("2024-03-01"),
+        exit_date=pandas.Timestamp("2024-04-01"),
+        entry_price=10.0,
+        exit_price=12.0,
+        profit=2.0 - TRADE_COMMISSION,
+        holding_period=1,
+    )
+    trade_gamma = Trade(
+        entry_date=pandas.Timestamp("2024-05-01"),
+        exit_date=pandas.Timestamp("2024-06-01"),
+        entry_price=10.0,
+        exit_price=9.0,
+        profit=-1.0 - TRADE_COMMISSION,
+        holding_period=1,
+    )
+    trade_counts = calculate_annual_trade_counts(
+        [trade_alpha, trade_beta, trade_gamma]
+    )
+    assert trade_counts == {2023: 1, 2024: 2}


### PR DESCRIPTION
## Summary
- compute yearly trade counts via `calculate_annual_trade_counts`
- extend `StrategyMetrics` and CLI to show trades per year
- fix EMA/SMA cross-with-slope signals to ignore long-term SMA and use tighter slope range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68ab98dc90b0832b8c3d49e5d5877350