### PR TITLE
Require long-term SMA filter for EMA/SMA slope strategy

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -188,19 +188,20 @@ def attach_ftd_ema_sma_cross_signals(
 def attach_ema_sma_cross_with_slope_signals(
     price_data_frame: pandas.DataFrame,
     window_size: int = 50,
-    slope_range: tuple[float, float] = (-0.3, 0.3),
+    slope_range: tuple[float, float] = (-0.4, 1.0),
 ) -> None:
     """Attach EMA/SMA cross signals filtered by SMA slope to ``price_data_frame``.
 
-    Unlike :func:`attach_ema_sma_cross_signals`, this variant does not require
-    the closing price to be above the long-term simple moving average.
+    Entry signals are generated only when the previous closing price is greater
+    than the long-term simple moving average and the slope of the simple moving
+    average lies within ``slope_range``.
     """
     # TODO: review
 
     attach_ema_sma_cross_signals(
         price_data_frame,
         window_size,
-        require_close_above_long_term_sma=False,
+        require_close_above_long_term_sma=True,
     )
     price_data_frame["sma_slope"] = (
         price_data_frame["sma_value"] - price_data_frame["sma_previous"]

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -634,10 +634,10 @@ def test_attach_ftd_ema_sma_cross_signals_requires_recent_ftd(
     ]
 
 
-def test_attach_ema_sma_cross_with_slope_requires_flat_sma(
+def test_attach_ema_sma_cross_with_slope_requires_close_above_long_term_sma_and_slope_in_range(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The EMA/SMA cross entry should require a flat SMA slope and not depend on the long-term SMA."""
+    """The EMA/SMA cross entry should require the closing price to be above the long-term SMA and a slope in range."""
     # TODO: review
 
     import stock_indicator.strategy as strategy_module
@@ -646,15 +646,15 @@ def test_attach_ema_sma_cross_with_slope_requires_flat_sma(
         {"open": [1.0, 1.0, 1.0], "close": [1.0, 1.0, 1.0]}
     )
 
-    recorded_require_close: bool | None = None
+    recorded_require_close_above_long_term_sma: bool | None = None
 
     def fake_attach_ema_sma_cross_signals(
         data_frame: pandas.DataFrame,
         window_size: int = 50,
         require_close_above_long_term_sma: bool = True,
     ) -> None:
-        nonlocal recorded_require_close
-        recorded_require_close = require_close_above_long_term_sma
+        nonlocal recorded_require_close_above_long_term_sma
+        recorded_require_close_above_long_term_sma = require_close_above_long_term_sma
         data_frame["sma_value"] = pandas.Series([1.0, 1.1, 1.5])
         data_frame["sma_previous"] = data_frame["sma_value"].shift(1)
         data_frame["ema_sma_cross_entry_signal"] = pandas.Series(
@@ -670,11 +670,11 @@ def test_attach_ema_sma_cross_with_slope_requires_flat_sma(
 
     strategy_module.attach_ema_sma_cross_with_slope_signals(price_data_frame)
 
-    assert recorded_require_close is False
+    assert recorded_require_close_above_long_term_sma is True
     assert list(price_data_frame["ema_sma_cross_with_slope_entry_signal"]) == [
         False,
         True,
-        False,
+        True,
     ]
     assert list(price_data_frame["ema_sma_cross_with_slope_exit_signal"]) == [
         False,


### PR DESCRIPTION
## Summary
- widen allowed SMA slope range to -0.4..1.0
- require closing price above long-term SMA in EMA/SMA slope strategy
- update tests for new slope and close-above-long-term requirement

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ab9b572848832b8965ced701ea5395