### PR TITLE
Add utility to count symbols by dollar volume

### DIFF
--- a/src/stock_indicator/volume.py
+++ b/src/stock_indicator/volume.py
@@ -1,0 +1,57 @@
+"""Utility functions for analyzing dollar volume across symbols."""
+# TODO: review
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas
+
+from .strategy import load_price_data
+
+
+def count_symbols_with_average_dollar_volume_above(
+    data_directory: Path, minimum_average_dollar_volume: float
+) -> int:
+    """Return the number of symbols whose 50-day average dollar volume exceeds a threshold.
+
+    Parameters
+    ----------
+    data_directory : Path
+        Directory containing CSV price data for individual symbols.
+    minimum_average_dollar_volume : float
+        Minimum 50-day average dollar volume, in millions, required for a symbol
+        to be counted.
+
+    Returns
+    -------
+    int
+        Number of symbols whose 50-day average dollar volume is greater than
+        ``minimum_average_dollar_volume``.
+
+    Raises
+    ------
+    ValueError
+        If a CSV file lacks the ``volume`` column required for dollar volume
+        calculations.
+    """
+    symbol_count = 0
+    for csv_file_path in data_directory.glob("*.csv"):
+        price_data_frame = load_price_data(csv_file_path)
+        if "volume" not in price_data_frame.columns:
+            raise ValueError(
+                "Volume column is required to compute dollar volume filter"
+            )
+        dollar_volume_series = (
+            price_data_frame["close"] * price_data_frame["volume"]
+        )
+        if dollar_volume_series.empty:
+            continue
+        recent_average_dollar_volume = (
+            dollar_volume_series.rolling(window=50).mean().iloc[-1] / 1_000_000
+        )
+        if pandas.isna(recent_average_dollar_volume):
+            continue
+        if recent_average_dollar_volume > minimum_average_dollar_volume:
+            symbol_count += 1
+    return symbol_count

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,0 +1,70 @@
+"""Tests for dollar volume analysis utilities."""
+# TODO: review
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas
+import pytest
+
+from stock_indicator.volume import (
+    count_symbols_with_average_dollar_volume_above,
+)
+
+
+def test_count_symbols_with_average_dollar_volume_above_returns_correct_count(
+    tmp_path: Path,
+) -> None:
+    """The function should count symbols above the specified dollar volume threshold."""
+
+    date_index = pandas.date_range("2020-01-01", periods=60, freq="D")
+
+    high_volume_price_values = [10.0] * 60
+    high_volume_volume_values = [1_000_000] * 60
+    high_volume_data_frame = pandas.DataFrame(
+        {
+            "Date": date_index,
+            "open": high_volume_price_values,
+            "close": high_volume_price_values,
+            "volume": high_volume_volume_values,
+        }
+    )
+    high_volume_data_frame.to_csv(tmp_path / "high.csv", index=False)
+
+    low_volume_price_values = [10.0] * 60
+    low_volume_volume_values = [200_000] * 60
+    low_volume_data_frame = pandas.DataFrame(
+        {
+            "Date": date_index,
+            "open": low_volume_price_values,
+            "close": low_volume_price_values,
+            "volume": low_volume_volume_values,
+        }
+    )
+    low_volume_data_frame.to_csv(tmp_path / "low.csv", index=False)
+
+    result = count_symbols_with_average_dollar_volume_above(tmp_path, 5)
+    assert result == 1
+
+    result = count_symbols_with_average_dollar_volume_above(tmp_path, 1)
+    assert result == 2
+
+
+def test_count_symbols_with_average_dollar_volume_above_requires_volume_column(
+    tmp_path: Path,
+) -> None:
+    """The function should raise when the volume column is missing."""
+
+    date_index = pandas.date_range("2020-01-01", periods=60, freq="D")
+    price_data_frame = pandas.DataFrame(
+        {
+            "Date": date_index,
+            "open": [10.0] * 60,
+            "close": [10.0] * 60,
+        }
+    )
+    price_data_frame.to_csv(tmp_path / "missing.csv", index=False)
+
+    with pytest.raises(ValueError, match="Volume column is required"):
+        count_symbols_with_average_dollar_volume_above(tmp_path, 1)


### PR DESCRIPTION
## Summary
- add function to count symbols whose 50-day average dollar volume exceeds a threshold
- cover counting and missing-volume scenarios with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68abdde60e78832b962ed3f294354f87