### PR TITLE
Add command for counting high-volume symbols

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -12,7 +12,7 @@ from typing import List
 
 from pandas import DataFrame
 
-from . import data_loader, symbols, strategy
+from . import data_loader, symbols, strategy, volume
 from .symbols import SP500_SYMBOL
 
 LOGGER = logging.getLogger(__name__)
@@ -183,6 +183,36 @@ class StockShell(cmd.Cmd):
             "Defaults to 1.0.\n"
             f"Available buy strategies: {available_buy}.\n"
             f"Available sell strategies: {available_sell}.\n"
+        )
+
+# TODO: review
+    def do_count_symbols_with_average_dollar_volume_above(self, argument_line: str) -> None:  # noqa: D401
+        """count_symbols_with_average_dollar_volume_above THRESHOLD
+        Count symbols whose 50-day average dollar volume exceeds THRESHOLD."""
+        argument_string = argument_line.strip()
+        if not argument_string:
+            self.stdout.write(
+                "usage: count_symbols_with_average_dollar_volume_above THRESHOLD\n"
+            )
+            return
+        try:
+            minimum_average_dollar_volume = float(argument_string)
+        except ValueError:
+            self.stdout.write(
+                "usage: count_symbols_with_average_dollar_volume_above THRESHOLD\n"
+            )
+            return
+        symbol_count = volume.count_symbols_with_average_dollar_volume_above(
+            DATA_DIRECTORY, minimum_average_dollar_volume
+        )
+        self.stdout.write(f"{symbol_count}\n")
+
+    # TODO: review
+    def help_count_symbols_with_average_dollar_volume_above(self) -> None:
+        """Display help for the count_symbols_with_average_dollar_volume_above command."""
+        self.stdout.write(
+            "count_symbols_with_average_dollar_volume_above THRESHOLD\n"
+            "Count symbols whose 50-day average dollar volume is greater than THRESHOLD in millions.\n"
         )
 
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -99,6 +99,31 @@ def test_update_all_data(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
     assert download_calls == expected_symbols
 
 
+# TODO: review
+def test_count_symbols_with_average_dollar_volume_above(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The command should report how many symbols exceed a dollar volume threshold."""
+    import stock_indicator.manage as manage_module
+
+    call_arguments: dict[str, float] = {}
+
+    def fake_counter(data_directory: Path, minimum_average_dollar_volume: float) -> int:
+        call_arguments["threshold"] = minimum_average_dollar_volume
+        assert data_directory == manage_module.DATA_DIRECTORY
+        return 7
+
+    monkeypatch.setattr(
+        manage_module.volume,
+        "count_symbols_with_average_dollar_volume_above",
+        fake_counter,
+    )
+
+    output_buffer = io.StringIO()
+    shell = manage_module.StockShell(stdout=output_buffer)
+    shell.onecmd("count_symbols_with_average_dollar_volume_above 10")
+    assert call_arguments["threshold"] == 10.0
+    assert output_buffer.getvalue().strip() == "7"
+
+
 def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     """The command should evaluate strategies and display metrics."""
     import stock_indicator.manage as manage_module


### PR DESCRIPTION
## Summary
- add `count_symbols_with_average_dollar_volume_above` command to management shell
- test counting of symbols exceeding a dollar volume threshold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68abe4507f24832ba79e072dbf6f36af