### PR TITLE
Invest remaining cash when building positions

### DIFF
--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -237,6 +237,9 @@ def simulate_portfolio_balance(
             if share_count <= 0:
                 continue
             invested_amount = share_count * trade.entry_price
+            if cash_balance - invested_amount >= trade.entry_price:
+                share_count += 1
+                invested_amount = share_count * trade.entry_price
             open_trades[trade] = invested_amount
             cash_balance -= invested_amount
     return cash_balance
@@ -316,6 +319,9 @@ def calculate_annual_returns(
             if share_count <= 0:
                 continue
             invested_amount = share_count * trade.entry_price
+            if cash_balance - invested_amount >= trade.entry_price:
+                share_count += 1
+                invested_amount = share_count * trade.entry_price
             open_trades[trade] = invested_amount
             cash_balance -= invested_amount
 

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -387,7 +387,7 @@ def evaluate_combined_strategy(
         Minimum 50-day moving average dollar volume, in millions, required for a
         symbol to be included in the evaluation. When ``None``, no filter is
         applied.
-    starting_cash: float, default 1000.0
+    starting_cash: float, default 3000.0
         Initial amount of cash used for portfolio simulation.
     stop_loss_percentage: float, default 1.0
         Fractional loss from the entry price that triggers an exit on the next

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -283,7 +283,32 @@ def test_simulate_portfolio_balance_allocates_budget_by_symbol_count() -> None:
     final_balance = simulate_portfolio_balance(
         [trade_alpha, trade_beta, trade_gamma], 100.0, 3
     )
-    expected_final_balance = 167.0
+    expected_final_balance = 157.0
+    assert pytest.approx(final_balance, rel=1e-6) == expected_final_balance
+
+
+def test_simulate_portfolio_balance_invests_additional_share_when_cash_available() -> None:
+    """Portfolio simulation should buy an extra share if cash remains."""
+    trade_primary = Trade(
+        entry_date=pandas.Timestamp("2024-01-01"),
+        exit_date=pandas.Timestamp("2024-01-03"),
+        entry_price=30.0,
+        exit_price=60.0,
+        profit=30.0,
+        holding_period=2,
+    )
+    trade_secondary = Trade(
+        entry_date=pandas.Timestamp("2024-01-02"),
+        exit_date=pandas.Timestamp("2024-01-04"),
+        entry_price=70.0,
+        exit_price=70.0,
+        profit=0.0,
+        holding_period=2,
+    )
+    final_balance = simulate_portfolio_balance(
+        [trade_primary, trade_secondary], 100.0, 2
+    )
+    expected_final_balance = 159.0
     assert pytest.approx(final_balance, rel=1e-6) == expected_final_balance
 
 


### PR DESCRIPTION
## Summary
- Buy an extra share when leftover cash exceeds the initial budget during portfolio simulation and annual return calculations
- Document default starting cash of $3,000
- Update and extend portfolio balance tests for the new purchase behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68ac12a5c5f4832b90886574cb5213d6