### PR TITLE
Use oldest available data date for daily job

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -13,6 +13,7 @@ from typing import List
 from pandas import DataFrame
 
 from . import data_loader, symbols, strategy, volume
+from .daily_job import determine_start_date
 from .symbols import SP500_SYMBOL
 
 LOGGER = logging.getLogger(__name__)
@@ -138,12 +139,17 @@ class StockShell(cmd.Cmd):
         if sell_strategy_name not in strategy.SELL_STRATEGIES:
             self.stdout.write("unsupported strategies\n")
             return
+
+        start_date_string = determine_start_date(DATA_DIRECTORY)
         evaluation_metrics = strategy.evaluate_combined_strategy(
             DATA_DIRECTORY,
             buy_strategy_name,
             sell_strategy_name,
             minimum_average_dollar_volume,
             stop_loss_percentage=stop_loss_percentage,
+        )
+        self.stdout.write(
+            f"Simulation start date: {start_date_string}\n"
         )
         self.stdout.write(
             (

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -172,6 +172,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     assert call_record["strategies"] == ("ema_sma_cross", "ema_sma_cross")
     assert volume_record["threshold"] == 500.0
     assert stop_loss_record["value"] == 1.0
+    assert "Simulation start date: 2019-01-01" in output_buffer.getvalue()
     assert (
         "Trades: 3, Win rate: 50.00%, Mean profit %: 10.00%, Profit % Std Dev: 0.00%, "
         "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "


### PR DESCRIPTION
## Summary
- derive start date from earliest cached CSV file so simulations run from oldest data
- cover daily job behavior with a new test ensuring old data is used
- print the earliest data date when running `start_simulate` to confirm simulation range

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ac22a95644832bbbb8711de3a09018