### PR TITLE
Use 50-day average dollar volume for ranking

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -6,6 +6,13 @@ To evaluate the FTD EMA and SMA cross strategy in the management shell, call:
 start_simulate dollar_volume>50 ftd_ema_sma_cross ftd_ema_sma_cross
 ```
 
+To restrict simulation to the six symbols with the highest 50-day average dollar
+volume, use:
+
+```
+start_simulate dollar_volume=6th ftd_ema_sma_cross ftd_ema_sma_cross
+```
+
 The previous `start_ftd_ema_sma_cross` command has been removed.
 Use `start_simulate` with `ftd_ema_sma_cross` for both the buying and
 selling strategies instead.

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -50,11 +50,30 @@ def test_parse_daily_task_arguments_returns_expected_values():
     argument_line = "dollar_volume>10000 ema_sma_cross ema_sma_cross 1.0"
     (
         minimum_average_dollar_volume,
+        top_dollar_volume_rank,
         buy_strategy_name,
         sell_strategy_name,
         stop_loss_percentage,
     ) = cron.parse_daily_task_arguments(argument_line)
     assert minimum_average_dollar_volume == 10000.0
+    assert top_dollar_volume_rank is None
+    assert buy_strategy_name == "ema_sma_cross"
+    assert sell_strategy_name == "ema_sma_cross"
+    assert stop_loss_percentage == 1.0
+
+
+def test_parse_daily_task_arguments_accepts_rank() -> None:
+    """The parser should accept ranking-based dollar volume filters."""
+    argument_line = "dollar_volume=5th ema_sma_cross ema_sma_cross"
+    (
+        minimum_average_dollar_volume,
+        top_dollar_volume_rank,
+        buy_strategy_name,
+        sell_strategy_name,
+        stop_loss_percentage,
+    ) = cron.parse_daily_task_arguments(argument_line)
+    assert minimum_average_dollar_volume is None
+    assert top_dollar_volume_rank == 5
     assert buy_strategy_name == "ema_sma_cross"
     assert sell_strategy_name == "ema_sma_cross"
     assert stop_loss_percentage == 1.0
@@ -88,3 +107,46 @@ def test_run_daily_tasks_skips_symbol_update_errors(monkeypatch):
     )
 
     assert result["entry_signals"] == ["TEST"]
+
+
+def test_run_daily_tasks_honors_dollar_volume_rank(tmp_path, monkeypatch):
+    """run_daily_tasks should process only the highest-ranked symbol."""
+
+    symbol_list = ["AAA", "BBB"]
+
+    def fake_update_symbol_cache() -> None:
+        return None
+
+    def fake_download_history(
+        symbol: str, start: str, end: str, cache_path: Path | None = None
+    ) -> pandas.DataFrame:
+        if symbol == "AAA":
+            volume_values = [1000.0] * 59 + [1.0]
+        else:
+            volume_values = [10.0] * 59 + [200.0]
+        frame = pandas.DataFrame({"close": [1.0] * 60, "volume": volume_values})
+        if cache_path is not None:
+            frame.to_csv(cache_path)
+        return frame
+
+    def fake_strategy(price_history_frame: pandas.DataFrame) -> None:
+        entry_signals = [False] * 59 + [True]
+        price_history_frame["fake_strategy_entry_signal"] = entry_signals
+        price_history_frame["fake_strategy_exit_signal"] = [False] * 60
+
+    monkeypatch.setattr(cron, "update_symbol_cache", fake_update_symbol_cache)
+    monkeypatch.setitem(strategy.SUPPORTED_STRATEGIES, "fake_strategy", fake_strategy)
+
+    result = cron.run_daily_tasks(
+        "fake_strategy",
+        "fake_strategy",
+        "2024-01-01",
+        "2024-01-10",
+        symbol_list=symbol_list,
+        data_download_function=fake_download_history,
+        data_directory=tmp_path,
+        top_dollar_volume_rank=1,
+    )
+
+    assert result["entry_signals"] == ["AAA"]
+    assert result["exit_signals"] == []


### PR DESCRIPTION
## Summary
- Support `dollar_volume=Nth` in daily job argument parsing
- Rank symbols by 50-day average dollar volume for simulations and daily tasks
- Document 50-day average dollar volume usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ac28d3cf18832baef5e761850893bf