### PR TITLE
Add 20/50 SMA cross strategy

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -36,12 +36,13 @@ selling strategies instead.
 The `start_simulate` command accepts the following strategies:
 
 * `ema_sma_cross`
+* `20_50_sma_cross`
 * `ema_sma_cross_and_rsi`
 * `ftd_ema_sma_cross`
 * `ema_sma_cross_with_slope`
 * `ema_sma_double_cross`
 * `kalman_filtering` *(sell only)*
 
-Not every strategy supports both buying and selling. Only the first five
-strategies in the list can be used for buying. All six strategies can be used
-for selling.
+Not every strategy supports both buying and selling. Only the first six
+strategies in the list can be used for buying. All seven strategies can be
+used for selling.

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -138,6 +138,30 @@ def attach_ema_sma_cross_signals(
     )
 
 
+def attach_20_50_sma_cross_signals(price_data_frame: pandas.DataFrame) -> None:
+    """Attach 20/50 SMA cross entry and exit signals to ``price_data_frame``."""
+    # TODO: review
+
+    price_data_frame["sma_20_value"] = sma(price_data_frame["close"], 20)
+    price_data_frame["sma_50_value"] = sma(price_data_frame["close"], 50)
+    price_data_frame["sma_20_previous"] = price_data_frame["sma_20_value"].shift(1)
+    price_data_frame["sma_50_previous"] = price_data_frame["sma_50_value"].shift(1)
+    sma_20_crosses_above_sma_50 = (
+        (price_data_frame["sma_20_previous"] <= price_data_frame["sma_50_previous"])
+        & (price_data_frame["sma_20_value"] > price_data_frame["sma_50_value"])
+    )
+    sma_20_crosses_below_sma_50 = (
+        (price_data_frame["sma_20_previous"] >= price_data_frame["sma_50_previous"])
+        & (price_data_frame["sma_20_value"] < price_data_frame["sma_50_value"])
+    )
+    price_data_frame["20_50_sma_cross_entry_signal"] = (
+        sma_20_crosses_above_sma_50.shift(1, fill_value=False)
+    )
+    price_data_frame["20_50_sma_cross_exit_signal"] = (
+        sma_20_crosses_below_sma_50.shift(1, fill_value=False)
+    )
+
+
 def attach_ema_sma_cross_and_rsi_signals(
     price_data_frame: pandas.DataFrame,
     window_size: int = 50,
@@ -282,6 +306,7 @@ def attach_kalman_filtering_signals(
 # TODO: review
 BUY_STRATEGIES: Dict[str, Callable[[pandas.DataFrame], None]] = {
     "ema_sma_cross": attach_ema_sma_cross_signals,
+    "20_50_sma_cross": attach_20_50_sma_cross_signals,
     "ema_sma_cross_and_rsi": attach_ema_sma_cross_and_rsi_signals,
     "ftd_ema_sma_cross": attach_ftd_ema_sma_cross_signals,
     "ema_sma_cross_with_slope": attach_ema_sma_cross_with_slope_signals,

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -431,6 +431,58 @@ def test_start_simulate_supports_slope_strategy(
     )
 
 
+def test_start_simulate_supports_20_50_sma_cross_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command should recognize the 20/50 SMA cross strategy."""
+    # TODO: review
+
+    import stock_indicator.manage as manage_module
+
+    call_arguments: dict[str, tuple[str, str]] = {}
+
+    from stock_indicator.strategy import StrategyMetrics
+
+    def fake_evaluate(
+        data_directory: Path,
+        buy_strategy_name: str,
+        sell_strategy_name: str,
+        minimum_average_dollar_volume: float | None,
+        top_dollar_volume_rank: int | None = None,
+        stop_loss_percentage: float = 1.0,
+    ) -> StrategyMetrics:
+        call_arguments["strategies"] = (buy_strategy_name, sell_strategy_name)
+        return StrategyMetrics(
+            total_trades=0,
+            win_rate=0.0,
+            mean_profit_percentage=0.0,
+            profit_percentage_standard_deviation=0.0,
+            mean_loss_percentage=0.0,
+            loss_percentage_standard_deviation=0.0,
+            mean_holding_period=0.0,
+            holding_period_standard_deviation=0.0,
+            maximum_concurrent_positions=0,
+            final_balance=0.0,
+            annual_returns={},
+            annual_trade_counts={},
+        )
+
+    monkeypatch.setattr(
+        manage_module.strategy,
+        "evaluate_combined_strategy",
+        fake_evaluate,
+    )
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd(
+        "start_simulate dollar_volume>0 20_50_sma_cross 20_50_sma_cross"
+    )
+    assert call_arguments["strategies"] == (
+        "20_50_sma_cross",
+        "20_50_sma_cross",
+    )
+
+
 def test_start_simulate_accepts_stop_loss_argument(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- introduce 20/50 SMA cross strategy with entry and exit signals
- expose the strategy to the simulation shell and document availability
- cover new strategy with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ad154fcf30832b86c1f896884cfb6d