### PR TITLE
Adjust SMA slope range to (-0.3, 1.0)

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -212,7 +212,7 @@ def attach_ftd_ema_sma_cross_signals(
 def attach_ema_sma_cross_with_slope_signals(
     price_data_frame: pandas.DataFrame,
     window_size: int = 50,
-    slope_range: tuple[float, float] = (-0.4, 1.0),
+    slope_range: tuple[float, float] = (-0.3, 1.0),
 ) -> None:
     """Attach EMA/SMA cross signals filtered by SMA slope to ``price_data_frame``.
 
@@ -220,7 +220,7 @@ def attach_ema_sma_cross_with_slope_signals(
     than the long-term simple moving average and the slope of the simple moving
     average lies within ``slope_range``.
 
-    The default ``slope_range`` is ``(-0.4, 1.0)``.
+    The default ``slope_range`` is ``(-0.3, 1.0)``.
     """
     # TODO: review
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -803,7 +803,7 @@ def test_attach_ema_sma_cross_with_slope_requires_close_above_long_term_sma_and_
         nonlocal recorded_require_close_above_long_term_sma
         recorded_require_close_above_long_term_sma = require_close_above_long_term_sma
         data_frame["sma_value"] = pandas.Series(
-            [1.0, 0.65, 0.75, 1.15, 0.70]
+            [1.0, 0.8, 0.9, 1.2, 0.7]
         )
         data_frame["sma_previous"] = data_frame["sma_value"].shift(1)
         data_frame["ema_sma_cross_entry_signal"] = pandas.Series(


### PR DESCRIPTION
## Summary
- update EMA/SMA cross with slope filter default to (-0.3, 1.0)
- realign strategy tests with new slope threshold

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ad5729471c832bb2aeb784f477a476