### PR TITLE
Add EMA/SMA slope and volume strategy

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -42,9 +42,10 @@ The `start_simulate` command accepts the following strategies:
 * `ema_sma_cross_and_rsi`
 * `ftd_ema_sma_cross`
 * `ema_sma_cross_with_slope`
+* `ema_sma_cross_with_slope_and_volume`
 * `ema_sma_double_cross`
 * `kalman_filtering` *(sell only)*
 
-Not every strategy supports both buying and selling. Only the first six
-strategies in the list can be used for buying. All seven strategies can be
+Not every strategy supports both buying and selling. Only the first seven
+strategies in the list can be used for buying. All eight strategies can be
 used for selling.

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -243,6 +243,38 @@ def attach_ema_sma_cross_with_slope_signals(
     ]
 
 
+def attach_ema_sma_cross_with_slope_and_volume_signals(
+    price_data_frame: pandas.DataFrame,
+    window_size: int = 50,
+    slope_range: tuple[float, float] = (-0.3, 1.0),
+) -> None:
+    """Attach EMA/SMA cross signals filtered by SMA slope and dollar volume."""
+    # TODO: review
+
+    attach_ema_sma_cross_with_slope_signals(
+        price_data_frame, window_size, slope_range
+    )
+    price_data_frame["dollar_volume_value"] = (
+        price_data_frame["close"] * price_data_frame["volume"]
+    )
+    price_data_frame["ema_dollar_volume_value"] = ema(
+        price_data_frame["dollar_volume_value"], window_size
+    )
+    price_data_frame["sma_dollar_volume_value"] = sma(
+        price_data_frame["dollar_volume_value"], window_size
+    )
+    price_data_frame["ema_sma_cross_with_slope_and_volume_entry_signal"] = (
+        price_data_frame["ema_sma_cross_with_slope_entry_signal"]
+        & (
+            price_data_frame["ema_dollar_volume_value"]
+            > price_data_frame["sma_dollar_volume_value"]
+        )
+    )
+    price_data_frame["ema_sma_cross_with_slope_and_volume_exit_signal"] = (
+        price_data_frame["ema_sma_cross_with_slope_exit_signal"]
+    )
+
+
 def attach_ema_sma_double_cross_signals(
     price_data_frame: pandas.DataFrame,
     window_size: int = 50,
@@ -312,6 +344,7 @@ BUY_STRATEGIES: Dict[str, Callable[[pandas.DataFrame], None]] = {
     "ema_sma_cross_and_rsi": attach_ema_sma_cross_and_rsi_signals,
     "ftd_ema_sma_cross": attach_ftd_ema_sma_cross_signals,
     "ema_sma_cross_with_slope": attach_ema_sma_cross_with_slope_signals,
+    "ema_sma_cross_with_slope_and_volume": attach_ema_sma_cross_with_slope_and_volume_signals,
     "ema_sma_double_cross": attach_ema_sma_double_cross_signals,
 }
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -455,6 +455,64 @@ def test_start_simulate_supports_slope_strategy(
     )
 
 
+def test_start_simulate_supports_slope_and_volume_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command should recognize the slope and volume strategy."""
+    # TODO: review
+
+    import stock_indicator.manage as manage_module
+
+    call_arguments: dict[str, tuple[str, str]] = {}
+
+    from stock_indicator.strategy import StrategyMetrics
+
+    def fake_evaluate(
+        data_directory: Path,
+        buy_strategy_name: str,
+        sell_strategy_name: str,
+        minimum_average_dollar_volume: float | None,
+        top_dollar_volume_rank: int | None = None,
+        starting_cash: float = 3000.0,
+        withdraw_amount: float = 0.0,
+        stop_loss_percentage: float = 1.0,
+    ) -> StrategyMetrics:
+        call_arguments["strategies"] = (buy_strategy_name, sell_strategy_name)
+        assert starting_cash == 3000.0
+        assert withdraw_amount == 0.0
+        return StrategyMetrics(
+            total_trades=0,
+            win_rate=0.0,
+            mean_profit_percentage=0.0,
+            profit_percentage_standard_deviation=0.0,
+            mean_loss_percentage=0.0,
+            loss_percentage_standard_deviation=0.0,
+            mean_holding_period=0.0,
+            holding_period_standard_deviation=0.0,
+            maximum_concurrent_positions=0,
+            final_balance=0.0,
+            annual_returns={},
+            annual_trade_counts={},
+        )
+
+    monkeypatch.setattr(
+        manage_module.strategy,
+        "evaluate_combined_strategy",
+        fake_evaluate,
+    )
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd(
+        "start_simulate dollar_volume>0 "
+        "ema_sma_cross_with_slope_and_volume "
+        "ema_sma_cross_with_slope_and_volume"
+    )
+    assert call_arguments["strategies"] == (
+        "ema_sma_cross_with_slope_and_volume",
+        "ema_sma_cross_with_slope_and_volume",
+    )
+
+
 def test_start_simulate_supports_20_50_sma_cross_strategy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -836,6 +836,52 @@ def test_attach_ema_sma_cross_with_slope_requires_close_above_long_term_sma_and_
     ]
 
 
+def test_attach_ema_sma_cross_with_slope_and_volume_requires_higher_ema_volume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entry requires EMA dollar volume to exceed the SMA value."""
+    # TODO: review
+
+    import stock_indicator.strategy as strategy_module
+
+    price_data_frame = pandas.DataFrame(
+        {
+            "open": [1.0, 1.0, 1.0, 1.0, 1.0],
+            "close": [1.0, 1.0, 1.0, 1.0, 1.0],
+            "volume": [1.0, 2.0, 3.0, 2.0, 1.0],
+        }
+    )
+
+    def fake_attach_ema_sma_cross_with_slope_signals(
+        data_frame: pandas.DataFrame,
+        window_size: int = 50,
+        slope_range: tuple[float, float] = (-0.3, 1.0),
+    ) -> None:
+        data_frame["ema_sma_cross_with_slope_entry_signal"] = pandas.Series(
+            [False, True, True, True, True]
+        )
+        data_frame["ema_sma_cross_with_slope_exit_signal"] = pandas.Series(
+            [False, False, False, False, True]
+        )
+
+    monkeypatch.setattr(
+        strategy_module,
+        "attach_ema_sma_cross_with_slope_signals",
+        fake_attach_ema_sma_cross_with_slope_signals,
+    )
+
+    strategy_module.attach_ema_sma_cross_with_slope_and_volume_signals(
+        price_data_frame, window_size=3
+    )
+
+    assert list(
+        price_data_frame["ema_sma_cross_with_slope_and_volume_entry_signal"]
+    ) == [False, False, True, False, False]
+    assert list(
+        price_data_frame["ema_sma_cross_with_slope_and_volume_exit_signal"]
+    ) == [False, False, False, False, True]
+
+
 def test_attach_ema_sma_double_cross_requires_long_term_ema(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -934,6 +980,21 @@ def test_supported_strategies_includes_ema_sma_cross_with_slope() -> None:
     assert (
         SUPPORTED_STRATEGIES["ema_sma_cross_with_slope"]
         is attach_ema_sma_cross_with_slope_signals
+    )
+
+
+def test_supported_strategies_includes_ema_sma_cross_with_slope_and_volume() -> None:
+    """``SUPPORTED_STRATEGIES`` should expose the slope and volume strategy."""
+    # TODO: review
+
+    from stock_indicator.strategy import (
+        SUPPORTED_STRATEGIES,
+        attach_ema_sma_cross_with_slope_and_volume_signals,
+    )
+
+    assert (
+        SUPPORTED_STRATEGIES["ema_sma_cross_with_slope_and_volume"]
+        is attach_ema_sma_cross_with_slope_and_volume_signals
     )
 
 


### PR DESCRIPTION
## Summary
- Add `ema_sma_cross_with_slope_and_volume` strategy combining slope filter with dollar-volume EMA vs SMA condition
- Expose new strategy through strategy registry for CLI access
- Document availability of the new strategy

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ad75257750832b8798f85d0e5d5167