### PR TITLE
Fix evaluation for Series volume values

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -619,13 +619,17 @@ def evaluate_combined_strategy(
                 ]
             else:
                 entry_volume = float("nan")
+            if isinstance(entry_volume, pandas.Series):  # TODO: review
+                entry_volume_value = float(entry_volume.iloc[0])
+            else:
+                entry_volume_value = float(entry_volume)
             total_entry_volume = total_fifty_day_average_dollar_volume_by_date.get(
                 completed_trade.entry_date, 0.0
             )
-            if pandas.isna(entry_volume) or total_entry_volume == 0:
+            if pandas.isna(entry_volume_value) or total_entry_volume == 0:
                 entry_ratio = 0.0
             else:
-                entry_ratio = float(entry_volume) / float(total_entry_volume)
+                entry_ratio = entry_volume_value / float(total_entry_volume)
             entry_detail = TradeDetail(
                 date=completed_trade.entry_date,
                 symbol=symbol_name,
@@ -640,13 +644,17 @@ def evaluate_combined_strategy(
                 ]
             else:
                 exit_volume = float("nan")
+            if isinstance(exit_volume, pandas.Series):  # TODO: review
+                exit_volume_value = float(exit_volume.iloc[0])
+            else:
+                exit_volume_value = float(exit_volume)
             total_exit_volume = total_fifty_day_average_dollar_volume_by_date.get(
                 completed_trade.exit_date, 0.0
             )
-            if pandas.isna(exit_volume) or total_exit_volume == 0:
+            if pandas.isna(exit_volume_value) or total_exit_volume == 0:
                 exit_ratio = 0.0
             else:
-                exit_ratio = float(exit_volume) / float(total_exit_volume)
+                exit_ratio = exit_volume_value / float(total_exit_volume)
             exit_detail = TradeDetail(
                 date=completed_trade.exit_date,
                 symbol=symbol_name,


### PR DESCRIPTION
## Summary
- handle pandas Series volumes when retrieving entry and exit averages in strategy evaluation

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m stock_indicator.manage` then `start_simulate starting_cash=260000 withdraw=50000 dollar_volume>10000,5th ema_sma_cross_with_slope ema_sma_cross 1.0`


------
https://chatgpt.com/codex/tasks/task_b_68ad846d6b34832bb0bc180181f10485