### PR TITLE
Adjust price and volume using yfinance adjusted close

### DIFF
--- a/src/stock_indicator/data_loader.py
+++ b/src/stock_indicator/data_loader.py
@@ -1,10 +1,9 @@
 """Functions for downloading historical stock market data.
 
 The :func:`download_history` utility normalizes all column names in the
-returned data frame to ``snake_case``. Starting with ``yfinance`` version
-``0.2.51``, the ``download`` function returns a ``close`` column that already
-reflects any dividends or stock splits, so no separate adjusted closing price
-is provided.
+returned data frame to ``snake_case`` and adjusts prices and volume to account
+for dividends and stock splits. The data retains both ``close`` and
+``adj_close`` columns.
 """
 # TODO: review
 
@@ -49,7 +48,8 @@ def download_history(
     Returns
     -------
     pandas.DataFrame
-        Data frame containing the historical data.
+        Data frame containing the historical data. Column names are normalized
+        to ``snake_case`` and include both ``close`` and ``adj_close`` values.
 
     Raises
     ------
@@ -75,6 +75,9 @@ def download_history(
                 return cached_frame
             start = next_download_date.strftime("%Y-%m-%d")
 
+    download_options = dict(download_options)
+    download_options["auto_adjust"] = False
+
     maximum_attempts = 3
     for attempt_number in range(1, maximum_attempts + 1):
         try:
@@ -87,10 +90,22 @@ def download_history(
             )
             if isinstance(downloaded_frame.columns, pandas.MultiIndex):
                 downloaded_frame.columns = downloaded_frame.columns.get_level_values(0)
+
+            adjustment_ratio = (
+                downloaded_frame["Adj Close"] / downloaded_frame["Close"]
+            )
+            for price_column_name in ["Open", "High", "Low", "Close"]:
+                downloaded_frame[price_column_name] = (
+                    downloaded_frame[price_column_name] * adjustment_ratio
+                )
+            downloaded_frame["Volume"] = (
+                downloaded_frame["Volume"] / adjustment_ratio
+            )
             downloaded_frame.columns = [
                 str(column_name).lower().replace(" ", "_")
                 for column_name in downloaded_frame.columns
             ]
+
             if not cached_frame.empty:
                 downloaded_frame = pandas.concat([cached_frame, downloaded_frame])
             if cache_path is not None:

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -21,24 +21,42 @@ from stock_indicator.data_loader import download_history
 
 
 def test_download_history_returns_dataframe(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The function should return data provided by yfinance."""
-    raw_dataframe = pandas.DataFrame({"Close": [1.0, 2.0]})
+    """The function should adjust price and volume data provided by yfinance."""
+    raw_dataframe = pandas.DataFrame(
+        {
+            "Open": [100.0, 200.0],
+            "High": [110.0, 210.0],
+            "Low": [90.0, 190.0],
+            "Close": [100.0, 200.0],
+            "Adj Close": [50.0, 100.0],
+            "Volume": [1000.0, 2000.0],
+        }
+    )
 
     def stubbed_download(
         symbol: str,
         start: str,
         end: str,
         progress: bool = False,
+        auto_adjust: bool = False,
     ) -> pandas.DataFrame:
-        return raw_dataframe
+        return raw_dataframe.copy()
 
     monkeypatch.setattr(
         "stock_indicator.data_loader.yfinance.download", stubbed_download
     )
     monkeypatch.setattr("stock_indicator.symbols.load_symbols", lambda: ["TEST"])
+    adjustment_ratio = raw_dataframe["Adj Close"] / raw_dataframe["Close"]
     result_dataframe = download_history("TEST", "2021-01-01", "2021-01-02")
-    expected_dataframe = raw_dataframe.rename(
-        columns=lambda name: name.lower().replace(" ", "_")
+    expected_dataframe = pandas.DataFrame(
+        {
+            "open": raw_dataframe["Open"] * adjustment_ratio,
+            "high": raw_dataframe["High"] * adjustment_ratio,
+            "low": raw_dataframe["Low"] * adjustment_ratio,
+            "close": raw_dataframe["Close"] * adjustment_ratio,
+            "adj_close": raw_dataframe["Adj Close"],
+            "volume": raw_dataframe["Volume"] / adjustment_ratio,
+        }
     )
     pandas.testing.assert_frame_equal(result_dataframe, expected_dataframe)
 
@@ -49,8 +67,12 @@ def test_download_history_flattens_multiindex_columns(
     """The function should flatten MultiIndex columns and normalize their names."""
     raw_dataframe = pandas.DataFrame(
         {
-            ("Close", "TEST"): [1.0],
-            ("Open", "TEST"): [1.5],
+            ("Open", "TEST"): [100.0],
+            ("High", "TEST"): [110.0],
+            ("Low", "TEST"): [90.0],
+            ("Close", "TEST"): [100.0],
+            ("Adj Close", "TEST"): [50.0],
+            ("Volume", "TEST"): [1000.0],
         }
     )
 
@@ -59,6 +81,7 @@ def test_download_history_flattens_multiindex_columns(
         start: str,
         end: str,
         progress: bool = False,
+        auto_adjust: bool = False,
     ) -> pandas.DataFrame:
         return raw_dataframe
 
@@ -67,7 +90,17 @@ def test_download_history_flattens_multiindex_columns(
     )
     monkeypatch.setattr("stock_indicator.symbols.load_symbols", lambda: ["TEST"])
     result_dataframe = download_history("TEST", "2021-01-01", "2021-01-02")
-    assert list(result_dataframe.columns) == ["close", "open"]
+    expected_frame = pandas.DataFrame(
+        {
+            "open": [50.0],
+            "high": [55.0],
+            "low": [45.0],
+            "close": [50.0],
+            "adj_close": [50.0],
+            "volume": [2000.0],
+        }
+    )
+    pandas.testing.assert_frame_equal(result_dataframe, expected_frame)
 
 
 def test_download_history_retries_on_failure(
@@ -75,13 +108,23 @@ def test_download_history_retries_on_failure(
 ) -> None:
     """The function should retry and log warnings on temporary failures."""
     call_counter = {"count": 0}
-    raw_dataframe = pandas.DataFrame({"Close": [1.0]})
+    raw_dataframe = pandas.DataFrame(
+        {
+            "Open": [100.0],
+            "High": [110.0],
+            "Low": [90.0],
+            "Close": [100.0],
+            "Adj Close": [50.0],
+            "Volume": [1000.0],
+        }
+    )
 
     def flaky_download(
         symbol: str,
         start: str,
         end: str,
         progress: bool = False,
+        auto_adjust: bool = False,
     ) -> pandas.DataFrame:
         call_counter["count"] += 1
         if call_counter["count"] < 3:
@@ -96,8 +139,15 @@ def test_download_history_retries_on_failure(
         result_dataframe = download_history("TEST", "2021-01-01", "2021-01-02")
 
     assert call_counter["count"] == 3
-    expected_dataframe = raw_dataframe.rename(
-        columns=lambda name: name.lower().replace(" ", "_")
+    expected_dataframe = pandas.DataFrame(
+        {
+            "open": [50.0],
+            "high": [55.0],
+            "low": [45.0],
+            "close": [50.0],
+            "adj_close": [50.0],
+            "volume": [2000.0],
+        }
     )
     pandas.testing.assert_frame_equal(result_dataframe, expected_dataframe)
     assert "Attempt 1 to download data for TEST failed" in caplog.text
@@ -113,6 +163,7 @@ def test_download_history_raises_after_max_attempts(
         start: str,
         end: str,
         progress: bool = False,
+        auto_adjust: bool = False,
     ) -> pandas.DataFrame:
         raise ValueError("permanent error")
 
@@ -140,7 +191,16 @@ def test_download_history_forwards_optional_arguments(
         **options: str,
     ) -> pandas.DataFrame:
         captured_arguments.update(options)
-        return pandas.DataFrame()
+        return pandas.DataFrame(
+            {
+                "Open": [100.0],
+                "High": [110.0],
+                "Low": [90.0],
+                "Close": [100.0],
+                "Adj Close": [100.0],
+                "Volume": [1000.0],
+            }
+        )
 
     monkeypatch.setattr(
         "stock_indicator.data_loader.yfinance.download", stubbed_download
@@ -155,14 +215,28 @@ def test_download_history_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     symbol_name = "TEST"
     cache_file_path = tmp_path / "TEST.csv"
     existing_frame = pandas.DataFrame(
-        {"close": [1.0, 2.0]},
+        {
+            "open": [50.0, 60.0],
+            "high": [55.0, 65.0],
+            "low": [45.0, 55.0],
+            "close": [50.0, 60.0],
+            "adj_close": [50.0, 60.0],
+            "volume": [2000.0, 3000.0],
+        },
         index=pandas.to_datetime(["2023-01-01", "2023-01-02"]),
     )
     existing_frame.to_csv(cache_file_path)
 
     captured_arguments: dict[str, str] = {}
     downloaded_raw_frame = pandas.DataFrame(
-        {"Close": [3.0, 4.0]},
+        {
+            "Open": [100.0, 120.0],
+            "High": [110.0, 130.0],
+            "Low": [90.0, 110.0],
+            "Close": [100.0, 120.0],
+            "Adj Close": [50.0, 60.0],
+            "Volume": [1000.0, 1200.0],
+        },
         index=pandas.to_datetime(["2023-01-03", "2023-01-04"]),
     )
 
@@ -171,6 +245,7 @@ def test_download_history_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         start: str,
         end: str,
         progress: bool = False,
+        auto_adjust: bool = False,
     ) -> pandas.DataFrame:
         captured_arguments["start"] = start
         captured_arguments["end"] = end

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -68,3 +68,26 @@ def test_count_symbols_with_average_dollar_volume_above_requires_volume_column(
 
     with pytest.raises(ValueError, match="Volume column is required"):
         count_symbols_with_average_dollar_volume_above(tmp_path, 1)
+
+
+def test_count_symbols_with_average_dollar_volume_above_computes_value_correctly(
+    tmp_path: Path,
+) -> None:
+    """The function should compute the correct 50-day average dollar volume."""
+
+    date_index = pandas.date_range("2020-01-01", periods=60, freq="D")
+    price_values = [10.0] * 60
+    volume_values = [1_000_000.0] * 60
+    data_frame = pandas.DataFrame(
+        {"Date": date_index, "open": price_values, "close": price_values, "volume": volume_values}
+    )
+    data_frame.to_csv(tmp_path / "single.csv", index=False)
+
+    below_threshold_result = count_symbols_with_average_dollar_volume_above(
+        tmp_path, 9.9
+    )
+    above_threshold_result = count_symbols_with_average_dollar_volume_above(
+        tmp_path, 10.1
+    )
+    assert below_threshold_result == 1
+    assert above_threshold_result == 0


### PR DESCRIPTION
## Summary
- ensure yfinance downloads include raw and adjusted close, retaining both columns
- rescale open, high, low, close and volume using adjustment ratio
- cover volume adjustment and dollar volume math in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ada0bcefec832ba75a504f95bf4972