### PR TITLE
Include SMA dollar volume metrics in trade details

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -213,7 +213,13 @@ class StockShell(cmd.Cmd):
             trade_details = evaluation_metrics.trade_details_by_year.get(year, [])  # TODO: review
             for trade_detail in trade_details:  # TODO: review
                 self.stdout.write(
-                    f"  {trade_detail.date.date()} {trade_detail.symbol} {trade_detail.action} {trade_detail.price:.2f} {trade_detail.simple_moving_average_dollar_volume_ratio:.4f}\n"
+                    (
+                        f"  {trade_detail.date.date()} {trade_detail.symbol} "
+                        f"{trade_detail.action} {trade_detail.price:.2f} "
+                        f"{trade_detail.simple_moving_average_dollar_volume_ratio:.4f} "
+                        f"{trade_detail.simple_moving_average_dollar_volume / 1_000_000:.2f}M "
+                        f"{trade_detail.total_simple_moving_average_dollar_volume / 1_000_000:.2f}M\n"
+                    )
                 )
 
     # TODO: review

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -37,6 +37,8 @@ class TradeDetail:
     symbol: str
     action: str
     price: float
+    simple_moving_average_dollar_volume: float
+    total_simple_moving_average_dollar_volume: float
     simple_moving_average_dollar_volume_ratio: float
 
 
@@ -652,6 +654,10 @@ def evaluate_combined_strategy(
                 symbol=symbol_name,
                 action="open",
                 price=completed_trade.entry_price,
+                simple_moving_average_dollar_volume=entry_average_dollar_volume_value,
+                total_simple_moving_average_dollar_volume=float(
+                    total_entry_average_dollar_volume
+                ),
                 simple_moving_average_dollar_volume_ratio=entry_ratio,
             )
             if completed_trade.exit_date in price_data_frame.index:
@@ -689,6 +695,10 @@ def evaluate_combined_strategy(
                 symbol=symbol_name,
                 action="close",
                 price=completed_trade.exit_price,
+                simple_moving_average_dollar_volume=exit_average_dollar_volume_value,
+                total_simple_moving_average_dollar_volume=float(
+                    total_exit_average_dollar_volume
+                ),
                 simple_moving_average_dollar_volume_ratio=exit_ratio,
             )
             trade_details_by_year.setdefault(

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -157,6 +157,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     symbol="AAA",
                     action="open",
                     price=10.0,
+                    simple_moving_average_dollar_volume=100_000_000.0,
+                    total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.1,
                 ),
                 TradeDetail(
@@ -164,6 +166,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     symbol="AAA",
                     action="close",
                     price=11.0,
+                    simple_moving_average_dollar_volume=100_000_000.0,
+                    total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.1,
                 ),
                 TradeDetail(
@@ -171,6 +175,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     symbol="BBB",
                     action="open",
                     price=20.0,
+                    simple_moving_average_dollar_volume=200_000_000.0,
+                    total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.2,
                 ),
                 TradeDetail(
@@ -178,6 +184,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     symbol="BBB",
                     action="close",
                     price=21.0,
+                    simple_moving_average_dollar_volume=200_000_000.0,
+                    total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.2,
                 ),
             ],
@@ -187,6 +195,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     symbol="CCC",
                     action="open",
                     price=30.0,
+                    simple_moving_average_dollar_volume=300_000_000.0,
+                    total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.3,
                 ),
                 TradeDetail(
@@ -194,6 +204,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     symbol="CCC",
                     action="close",
                     price=29.0,
+                    simple_moving_average_dollar_volume=300_000_000.0,
+                    total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.3,
                 ),
             ],
@@ -234,10 +246,22 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     assert "Year 2023: 10.00%, trade: 2" in output_buffer.getvalue()
     assert "Year 2024: -5.00%, trade: 1" in output_buffer.getvalue()
-    assert "  2023-01-02 AAA open 10.00 0.1000" in output_buffer.getvalue()
-    assert "  2023-01-05 AAA close 11.00 0.1000" in output_buffer.getvalue()
-    assert "  2024-03-01 CCC open 30.00 0.3000" in output_buffer.getvalue()
-    assert "  2024-03-05 CCC close 29.00 0.3000" in output_buffer.getvalue()
+    assert (
+        "  2023-01-02 AAA open 10.00 0.1000 100.00M 1000.00M"
+        in output_buffer.getvalue()
+    )
+    assert (
+        "  2023-01-05 AAA close 11.00 0.1000 100.00M 1000.00M"
+        in output_buffer.getvalue()
+    )
+    assert (
+        "  2024-03-01 CCC open 30.00 0.3000 300.00M 1000.00M"
+        in output_buffer.getvalue()
+    )
+    assert (
+        "  2024-03-05 CCC close 29.00 0.3000 300.00M 1000.00M"
+        in output_buffer.getvalue()
+    )
 
 
 def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Track each trade's SMA dollar volume and total market SMA dollar volume
- Display SMA dollar volume metrics alongside trade ratio in `start_simulate` output
- Adjust tests for new trade detail fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68adc845f4a4832ba4ab13804e46c4da