### PR TITLE
Display win/loss outcome for closed trades

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -212,11 +212,19 @@ class StockShell(cmd.Cmd):
             )
             trade_details = evaluation_metrics.trade_details_by_year.get(year, [])  # TODO: review
             for trade_detail in trade_details:  # TODO: review
-                result_suffix = (
-                    f" {trade_detail.result}"  # TODO: review
-                    if trade_detail.action == "close" and trade_detail.result is not None
-                    else ""
-                )
+                if (
+                    trade_detail.action == "close"
+                    and trade_detail.result is not None
+                ):
+                    if trade_detail.percentage_change is not None:
+                        result_suffix = (
+                            f" {trade_detail.result} "
+                            f"{trade_detail.percentage_change:.2%}"
+                        )
+                    else:
+                        result_suffix = f" {trade_detail.result}"
+                else:
+                    result_suffix = ""
                 self.stdout.write(
                     (
                         f"  {trade_detail.date.date()} {trade_detail.symbol} "

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -212,13 +212,19 @@ class StockShell(cmd.Cmd):
             )
             trade_details = evaluation_metrics.trade_details_by_year.get(year, [])  # TODO: review
             for trade_detail in trade_details:  # TODO: review
+                result_suffix = (
+                    f" {trade_detail.result}"  # TODO: review
+                    if trade_detail.action == "close" and trade_detail.result is not None
+                    else ""
+                )
                 self.stdout.write(
                     (
                         f"  {trade_detail.date.date()} {trade_detail.symbol} "
                         f"{trade_detail.action} {trade_detail.price:.2f} "
                         f"{trade_detail.simple_moving_average_dollar_volume_ratio:.4f} "
                         f"{trade_detail.simple_moving_average_dollar_volume / 1_000_000:.2f}M "
-                        f"{trade_detail.total_simple_moving_average_dollar_volume / 1_000_000:.2f}M\n"
+                        f"{trade_detail.total_simple_moving_average_dollar_volume / 1_000_000:.2f}M"
+                        f"{result_suffix}\n"
                     )
                 )
 

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -37,6 +37,9 @@ class TradeDetail:
     dollar volume used when selecting symbols. The ratio expresses this
     symbol's share of the summed average dollar volume across all eligible
     symbols.
+
+    The ``result`` field marks whether a closed trade ended in a win or a
+    loss.
     """
     # TODO: review
     date: pandas.Timestamp
@@ -46,6 +49,7 @@ class TradeDetail:
     simple_moving_average_dollar_volume: float
     total_simple_moving_average_dollar_volume: float
     simple_moving_average_dollar_volume_ratio: float
+    result: str | None = None  # TODO: review
 
 
 @dataclass
@@ -656,6 +660,7 @@ def evaluate_combined_strategy(
                 total_simple_moving_average_dollar_volume=total_entry_dollar_volume,
                 simple_moving_average_dollar_volume_ratio=entry_volume_ratio,
             )
+            trade_result = "win" if completed_trade.profit > 0 else "lose"  # TODO: review
             exit_detail = TradeDetail(
                 date=completed_trade.exit_date,
                 symbol=symbol_name,
@@ -664,6 +669,7 @@ def evaluate_combined_strategy(
                 simple_moving_average_dollar_volume=exit_dollar_volume,
                 total_simple_moving_average_dollar_volume=total_exit_dollar_volume,
                 simple_moving_average_dollar_volume_ratio=exit_volume_ratio,
+                result=trade_result,
             )
             trade_details_by_year.setdefault(
                 completed_trade.entry_date.year, []

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -39,7 +39,8 @@ class TradeDetail:
     symbols.
 
     The ``result`` field marks whether a closed trade ended in a win or a
-    loss.
+    loss. For closing trades, ``percentage_change`` records the fractional
+    price change between entry and exit.
     """
     # TODO: review
     date: pandas.Timestamp
@@ -50,6 +51,7 @@ class TradeDetail:
     total_simple_moving_average_dollar_volume: float
     simple_moving_average_dollar_volume_ratio: float
     result: str | None = None  # TODO: review
+    percentage_change: float | None = None  # TODO: review
 
 
 @dataclass
@@ -670,6 +672,7 @@ def evaluate_combined_strategy(
                 total_simple_moving_average_dollar_volume=total_exit_dollar_volume,
                 simple_moving_average_dollar_volume_ratio=exit_volume_ratio,
                 result=trade_result,
+                percentage_change=percentage_change,
             )
             trade_details_by_year.setdefault(
                 completed_trade.entry_date.year, []

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -170,6 +170,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.1,
                     result="win",
+                    percentage_change=0.1,
                 ),
                 TradeDetail(
                     date=pandas.Timestamp("2023-02-10"),
@@ -189,6 +190,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.2,
                     result="win",
+                    percentage_change=0.05,
                 ),
             ],
             2024: [
@@ -210,6 +212,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.3,
                     result="lose",
+                    percentage_change=-1.0 / 30.0,
                 ),
             ],
         }
@@ -254,7 +257,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         in output_buffer.getvalue()
     )
     assert (
-        "  2023-01-05 AAA close 11.00 0.1000 100.00M 1000.00M win"
+        "  2023-01-05 AAA close 11.00 0.1000 100.00M 1000.00M win 10.00%"
         in output_buffer.getvalue()
     )
     assert (
@@ -262,7 +265,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         in output_buffer.getvalue()
     )
     assert (
-        "  2024-03-05 CCC close 29.00 0.3000 300.00M 1000.00M lose"
+        "  2024-03-05 CCC close 29.00 0.3000 300.00M 1000.00M lose -3.33%"
         in output_buffer.getvalue()
     )
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -169,6 +169,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     simple_moving_average_dollar_volume=100_000_000.0,
                     total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.1,
+                    result="win",
                 ),
                 TradeDetail(
                     date=pandas.Timestamp("2023-02-10"),
@@ -187,6 +188,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     simple_moving_average_dollar_volume=200_000_000.0,
                     total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.2,
+                    result="win",
                 ),
             ],
             2024: [
@@ -207,6 +209,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     simple_moving_average_dollar_volume=300_000_000.0,
                     total_simple_moving_average_dollar_volume=1_000_000_000.0,
                     simple_moving_average_dollar_volume_ratio=0.3,
+                    result="lose",
                 ),
             ],
         }
@@ -251,7 +254,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         in output_buffer.getvalue()
     )
     assert (
-        "  2023-01-05 AAA close 11.00 0.1000 100.00M 1000.00M"
+        "  2023-01-05 AAA close 11.00 0.1000 100.00M 1000.00M win"
         in output_buffer.getvalue()
     )
     assert (
@@ -259,7 +262,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         in output_buffer.getvalue()
     )
     assert (
-        "  2024-03-05 CCC close 29.00 0.3000 300.00M 1000.00M"
+        "  2024-03-05 CCC close 29.00 0.3000 300.00M 1000.00M lose"
         in output_buffer.getvalue()
     )
 


### PR DESCRIPTION
## Summary
- Extend `TradeDetail` with a `result` field indicating trade outcomes
- Mark trade closures as wins or losses when generating trade detail reports
- Show win/loss markers in `start_simulate` output and adjust tests accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68adf71a33e8832bb23152f62c7b14ad