### PR TITLE
Ensure price data uses unique sorted dates

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -75,12 +75,20 @@ class StrategyMetrics:
 
 
 def load_price_data(csv_file_path: Path) -> pandas.DataFrame:
-    """Load price data from ``csv_file_path`` and normalize column names."""
+    """Load price data from ``csv_file_path`` and normalize column names.
+
+    Duplicate dates are removed and the index is sorted to ensure that the
+    resulting frame has unique, chronologically ordered entries.
+    """
     # TODO: review
 
     price_data_frame = pandas.read_csv(
         csv_file_path, parse_dates=["Date"], index_col="Date"
     )
+    price_data_frame = price_data_frame.loc[
+        ~price_data_frame.index.duplicated(keep="first")
+    ]
+    price_data_frame.sort_index(inplace=True)
     if isinstance(price_data_frame.columns, pandas.MultiIndex):
         price_data_frame.columns = price_data_frame.columns.get_level_values(0)
     price_data_frame.columns = [


### PR DESCRIPTION
## Summary
- Drop duplicate dates from CSV data and sort the index in `load_price_data`
- Document that the function returns a cleaned, chronologically ordered DataFrame

## Testing
- `pytest`
- `python - <<'PYTHON'
import io
from pathlib import Path
import pandas
import sys
sys.path.append('src')
import stock_indicator.manage as manage_module
import stock_indicator.strategy as strategy_module

# Prepare data directory
data_dir = manage_module.DATA_DIRECTORY
if data_dir.exists():
    for item in data_dir.iterdir():
        if item.is_file():
            item.unlink()
else:
    data_dir.mkdir()

# Create CSV with duplicate dates
price_data_frame = pandas.DataFrame(
    {
        'Date': ['2023-01-01','2023-01-01','2023-01-02','2023-01-03'],
        'open': [10.0,10.0,10.0,10.0],
        'close': [10.0,10.0,10.0,10.0],
        'volume': [1000,1000,1000,1000],
    }
)
price_data_frame.to_csv(data_dir/'AAA.csv', index=False)
price_data_frame.to_csv(data_dir/'^GSPC.csv', index=False)

strategy_module.BUY_STRATEGIES['noop'] = lambda frame: None
strategy_module.SELL_STRATEGIES['noop'] = lambda frame: None

output_buffer = io.StringIO()
shell = manage_module.StockShell(stdout=output_buffer)
shell.onecmd('start_simulate dollar_volume>0 noop noop')
print(output_buffer.getvalue())
PYTHON`

------
https://chatgpt.com/codex/tasks/task_b_68ae75c8f7a8832bb80e7d595ca6e2ea