### PR TITLE
Document find_signal command and log parsing

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -33,6 +33,28 @@ The previous `start_ftd_ema_sma_cross` command has been removed.
 Use `start_simulate` with `ftd_ema_sma_cross` for both the buying and
 selling strategies instead.
 
+## Inspecting logged signals
+
+Each execution of the daily job records entry and exit signals in a log file in
+the project's `logs` directory. The files follow the `<YYYY-MM-DD>.log` naming
+convention, for example `logs/2024-01-10.log`. The management shell can parse a
+log file with:
+
+```
+find_signal 2024-01-10
+```
+
+The command prints the entry signal list on the first line and the exit signal
+list on the second line:
+
+```
+['AAA', 'BBB']
+['CCC', 'DDD']
+```
+
+Developers may call `daily_job.find_signal("2024-01-10")` to obtain the same
+data from Python code.
+
 ## Available strategies
 
 The `start_simulate` command accepts the following strategies:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ python -m stock_indicator.manage
 * `update_data SYMBOL START END` saves historical data for the given symbol to
   `data/<SYMBOL>.csv`.
 * `update_all_data START END` performs the download for every cached symbol.
+* `find_signal DATE` prints the entry and exit signals stored in
+  `logs/<DATE>.log`.
+
+Log files reside in the project's `logs` directory and are named after the
+recorded date. To view the signals from `logs/2024-01-10.log`, run:
+
+```bash
+(stock-indicator) find_signal 2024-01-10
+['AAA', 'BBB']
+['CCC', 'DDD']
+```
+
+Developers can also call `daily_job.find_signal("2024-01-10")` to retrieve the
+same data from Python code.
 
 The shell can also simulate trading strategies. The `dollar_volume` filter
 accepts both a minimum threshold and a ranking when the two are separated by a


### PR DESCRIPTION
## Summary
- Explain how to use `find_signal DATE` in the management shell
- Document `daily_job.find_signal` for programmatic access
- Describe log file location and naming

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae7fe4decc832b9a5a8843349b0f7f