### PR TITLE
feat: call cron directly for signal lookup

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -37,23 +37,22 @@ selling strategies instead.
 
 Each execution of the daily job records entry and exit signals in a log file in
 the project's `logs` directory. The files follow the `<YYYY-MM-DD>.log` naming
-convention, for example `logs/2024-01-10.log`. The management shell can parse a
-log file with:
+The management shell can compute signals for a specific day with:
 
 ```
-find_signal 2024-01-10
+find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
 ```
 
 The command prints the entry signal list on the first line and the exit signal
-list on the second line:
+list on the second line. For example:
 
 ```
+find_signal 2024-01-10 dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
 ['AAA', 'BBB']
 ['CCC', 'DDD']
 ```
 
-Developers may call `daily_job.find_signal("2024-01-10")` to obtain the same
-data from Python code.
+Developers may call `daily_job.find_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)` to obtain the same data from Python code.
 
 ## Available strategies
 

--- a/README.md
+++ b/README.md
@@ -64,20 +64,18 @@ python -m stock_indicator.manage
 * `update_data SYMBOL START END` saves historical data for the given symbol to
   `data/<SYMBOL>.csv`.
 * `update_all_data START END` performs the download for every cached symbol.
-* `find_signal DATE` prints the entry and exit signals stored in
-  `logs/<DATE>.log`.
+* `find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS`
+  prints the entry and exit signals for `DATE` using the provided strategies.
 
-Log files reside in the project's `logs` directory and are named after the
-recorded date. To view the signals from `logs/2024-01-10.log`, run:
+For example:
 
 ```bash
-(stock-indicator) find_signal 2024-01-10
+(stock-indicator) find_signal 2024-01-10 dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
 ['AAA', 'BBB']
 ['CCC', 'DDD']
 ```
 
-Developers can also call `daily_job.find_signal("2024-01-10")` to retrieve the
-same data from Python code.
+Developers can also call `daily_job.find_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)` to compute the same data from Python code.
 
 The shell can also simulate trading strategies. The `dollar_volume` filter
 accepts both a minimum threshold and a ranking when the two are separated by a

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -290,19 +290,22 @@ class StockShell(cmd.Cmd):
 
     # TODO: review
     def do_find_signal(self, argument_line: str) -> None:  # noqa: D401
-        """find_signal DATE
-        Display the entry and exit signals logged for DATE."""
+        """find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
+        Display the entry and exit signals generated for DATE."""
         argument_parts: List[str] = argument_line.split()
-        if len(argument_parts) != 1 or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", argument_parts[0]):
-            self.stdout.write("usage: find_signal DATE\n")
+        if len(argument_parts) != 5 or not re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}", argument_parts[0]
+        ):
+            self.stdout.write(
+                "usage: find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS\n"
+            )
             return
-        date_string = argument_parts[0]
-        try:
-            signal_data: Dict[str, List[str]] = daily_job.find_signal(date_string)
-        except FileNotFoundError as error:
-            LOGGER.error("%s", error)
-            self.stdout.write(f"{error}\n")
-            return
+        date_string, dollar_volume_filter, buy_strategy, sell_strategy, stop_loss = (
+            argument_parts
+        )
+        signal_data: Dict[str, List[str]] = daily_job.find_signal(
+            date_string, dollar_volume_filter, buy_strategy, sell_strategy, float(stop_loss)
+        )
         entry_signal_list: List[str] = signal_data.get("entry_signals", [])
         exit_signal_list: List[str] = signal_data.get("exit_signals", [])
         self.stdout.write(f"{entry_signal_list}\n")
@@ -312,8 +315,8 @@ class StockShell(cmd.Cmd):
     def help_find_signal(self) -> None:
         """Display help for the find_signal command."""
         self.stdout.write(
-            "find_signal DATE\n"
-            "Display entry and exit signals stored in the log for DATE in YYYY-MM-DD format.\n"
+            "find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS\n"
+            "Display entry and exit signals for DATE using the provided strategies.\n"
         )
 
 

--- a/tests/test_daily_job.py
+++ b/tests/test_daily_job.py
@@ -83,31 +83,37 @@ def test_run_daily_job_uses_oldest_data_date(tmp_path, monkeypatch):
 
     assert captured_start_date["value"] == "2018-06-01"
 
-def test_find_signal_returns_expected_symbols(tmp_path):
-    """find_signal should return symbol lists stored in the log file."""
+def test_find_signal_invokes_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    """find_signal should call cron with the correct arguments."""
 
-    log_directory = tmp_path / "logs"
-    log_directory.mkdir()
-    sample_log_path = log_directory / "2024-01-10.log"
-    sample_log_path.write_text(
-        "entry_signals: AAA, BBB\nexit_signals: CCC, DDD\n", encoding="utf-8"
+    captured: dict[str, str] = {}
+
+    def fake_run_daily_tasks_from_argument(
+        argument_line: str,
+        start_date: str,
+        end_date: str,
+        symbol_list=None,
+        data_download_function=None,
+        data_directory: Path | None = None,
+    ):
+        captured["argument_line"] = argument_line
+        captured["start_date"] = start_date
+        captured["end_date"] = end_date
+        return {"entry_signals": ["AAA"], "exit_signals": ["BBB"]}
+
+    monkeypatch.setattr(
+        daily_job.cron, "run_daily_tasks_from_argument", fake_run_daily_tasks_from_argument
     )
 
     signal_dictionary = daily_job.find_signal(
-        "2024-01-10", log_directory=log_directory
+        "2024-01-10",
+        "dollar_volume>1",
+        "ema_sma_cross",
+        "ema_sma_cross",
+        1.0,
     )
 
-    assert signal_dictionary == {
-        "entry_signals": ["AAA", "BBB"],
-        "exit_signals": ["CCC", "DDD"],
-    }
-
-
-def test_find_signal_raises_file_not_found_error(tmp_path):
-    """find_signal should raise FileNotFoundError when the log is absent."""
-
-    log_directory = tmp_path / "logs"
-    log_directory.mkdir()
-
-    with pytest.raises(FileNotFoundError):
-        daily_job.find_signal("2024-01-10", log_directory=log_directory)
+    assert captured["argument_line"] == "dollar_volume>1 ema_sma_cross ema_sma_cross 1.0"
+    assert captured["start_date"] == "2024-01-10"
+    assert captured["end_date"] == "2024-01-10"
+    assert signal_dictionary == {"entry_signals": ["AAA"], "exit_signals": ["BBB"]}


### PR DESCRIPTION
## Summary
- compute signals for a specific date by invoking `cron.run_daily_tasks_from_argument` instead of parsing log files
- expand shell `find_signal` command to accept filter and strategy parameters
- document new `find_signal` usage

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae8a6b95cc832b8f418043714ec5c2