### PR TITLE
Document find_signal recalculation

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -33,11 +33,13 @@ The previous `start_ftd_ema_sma_cross` command has been removed.
 Use `start_simulate` with `ftd_ema_sma_cross` for both the buying and
 selling strategies instead.
 
-## Inspecting logged signals
+## Recalculating signals
 
 Each execution of the daily job records entry and exit signals in a log file in
-the project's `logs` directory. The files follow the `<YYYY-MM-DD>.log` naming
-The management shell can compute signals for a specific day with:
+the project's `logs` directory using the `<YYYY-MM-DD>.log` naming convention.
+The `find_signal` command recalculates the signals for a specific date rather
+than reading the log files. The management shell can compute signals for a
+specific day with:
 
 ```
 find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
@@ -52,7 +54,9 @@ find_signal 2024-01-10 dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
 ['CCC', 'DDD']
 ```
 
-Developers may call `daily_job.find_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)` to obtain the same data from Python code.
+Developers may call `daily_job.find_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)` to compute
+the same values from Python code. This function also recalculates signals
+instead of reading log files.
 
 ## Available strategies
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ python -m stock_indicator.manage
   `data/<SYMBOL>.csv`.
 * `update_all_data START END` performs the download for every cached symbol.
 * `find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS`
-  prints the entry and exit signals for `DATE` using the provided strategies.
+  recalculates the entry and exit signals for `DATE` using the provided
+  strategies instead of reading log files.
 
 For example:
 
@@ -75,7 +76,9 @@ For example:
 ['CCC', 'DDD']
 ```
 
-Developers can also call `daily_job.find_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)` to compute the same data from Python code.
+Developers can also call `daily_job.find_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)` to compute
+the same data from Python code. This function recalculates signals rather than
+reading them from log files.
 
 The shell can also simulate trading strategies. The `dollar_volume` filter
 accepts both a minimum threshold and a ranking when the two are separated by a


### PR DESCRIPTION
## Summary
- Clarify that `find_signal` recomputes signals instead of reading log files
- Document `find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS` usage in README and usage guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ae8c4e5460832bac003495b13d12c9