### PR TITLE
Support percentage-based dollar volume filter

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -6,6 +6,13 @@ To evaluate the FTD EMA and SMA cross strategy in the management shell, call:
 start_simulate dollar_volume>50 ftd_ema_sma_cross ftd_ema_sma_cross
 ```
 
+To require that a symbol's 50-day average dollar volume exceeds one percent of
+the market total, use:
+
+```
+start_simulate dollar_volume>1% ftd_ema_sma_cross ftd_ema_sma_cross
+```
+
 To restrict simulation to the six symbols with the highest 50-day average dollar
 volume, use:
 
@@ -21,10 +28,11 @@ start_simulate starting_cash=5000 withdraw=1000 dollar_volume>10000,6th ftd_ema_
 
 The optional `starting_cash` argument sets the initial portfolio balance, and
 `withdraw` deducts a fixed amount at each year end. The `dollar_volume` clause
-accepts a `>` threshold and an `=Nth` ranking. When both are separated by a
-comma, the parser applies them sequentially. The command above first filters
-symbols to those whose 50-day average dollar volume exceeds 10,000 million and
-then selects the six symbols with the highest remaining averages. The tests
+accepts a `>` threshold expressed in millions or as a percentage using `%`, and
+an `=Nth` ranking. When both are separated by a comma, the parser applies them
+sequentially. The command above first filters symbols to those whose 50-day
+average dollar volume exceeds 10,000 million and then selects the six symbols
+with the highest remaining averages. The tests
 `tests/test_manage.py::test_start_simulate_dollar_volume_threshold_and_rank` and
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 exercise this combined syntax.

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ the same data from Python code. This function recalculates signals rather than
 reading them from log files.
 
 The shell can also simulate trading strategies. The `dollar_volume` filter
-accepts both a minimum threshold and a ranking when the two are separated by a
-comma. The command below evaluates `ftd_ema_sma_cross` using only the six
-symbols whose 50-day average dollar volume exceeds 10,000 million:
+accepts a minimum threshold in millions, a percentage of total market volume,
+and a ranking when combined with a comma. The command below evaluates
+`ftd_ema_sma_cross` using only the six symbols whose 50-day average dollar
+volume exceeds 10,000 million:
 
 ```bash
 (stock-indicator) start_simulate starting_cash=5000 withdraw=1000 dollar_volume>10000,6th ftd_ema_sma_cross ftd_ema_sma_cross
@@ -94,6 +95,11 @@ selects the six highest-volume symbols from the remainder. The tests
 `tests/test_manage.py::test_start_simulate_dollar_volume_threshold_and_rank` and
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 demonstrate this combined syntax.
+
+To express the threshold as a percentage of total market dollar volume, use a
+percent sign. For example `dollar_volume>1%` retains only symbols whose
+50-day average dollar volume is greater than one percent of the combined
+volume across all symbols.
 
 ## Contribution Guidelines
 1. Fork the repository and create a new branch for each feature or bug fix.

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -209,12 +209,15 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
     ) -> StrategyMetrics:
         call_record["strategies"] = (buy_strategy_name, sell_strategy_name)
         volume_record["threshold"] = minimum_average_dollar_volume
+        if minimum_average_dollar_volume_ratio is not None:
+            volume_record["ratio"] = minimum_average_dollar_volume_ratio
         stop_loss_record["value"] = stop_loss_percentage
         assert starting_cash == 3000.0
         assert withdraw_amount == 0.0
@@ -355,6 +358,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
@@ -409,6 +413,7 @@ def test_start_simulate_dollar_volume_rank(monkeypatch: pytest.MonkeyPatch) -> N
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
@@ -442,6 +447,52 @@ def test_start_simulate_dollar_volume_rank(monkeypatch: pytest.MonkeyPatch) -> N
     assert rank_record["rank"] == 6
 
 
+def test_start_simulate_dollar_volume_ratio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The command should forward the ratio filter to evaluation."""
+    import stock_indicator.manage as manage_module
+
+    ratio_record: dict[str, float | None] = {}
+
+    from stock_indicator.strategy import StrategyMetrics
+
+    def fake_evaluate(
+        data_directory: Path,
+        buy_strategy_name: str,
+        sell_strategy_name: str,
+        minimum_average_dollar_volume: float | None,
+        top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
+        starting_cash: float = 3000.0,
+        withdraw_amount: float = 0.0,
+        stop_loss_percentage: float = 1.0,
+    ) -> StrategyMetrics:
+        ratio_record["ratio"] = minimum_average_dollar_volume_ratio
+        return StrategyMetrics(
+            total_trades=0,
+            win_rate=0.0,
+            mean_profit_percentage=0.0,
+            profit_percentage_standard_deviation=0.0,
+            mean_loss_percentage=0.0,
+            loss_percentage_standard_deviation=0.0,
+            mean_holding_period=0.0,
+            holding_period_standard_deviation=0.0,
+            maximum_concurrent_positions=0,
+            final_balance=0.0,
+            annual_returns={},
+            annual_trade_counts={},
+        )
+
+    monkeypatch.setattr(
+        manage_module.strategy,
+        "evaluate_combined_strategy",
+        fake_evaluate,
+    )
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd("start_simulate dollar_volume>1% ema_sma_cross ema_sma_cross")
+    assert ratio_record["ratio"] == 0.01
+
+
 def test_start_simulate_dollar_volume_threshold_and_rank(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -458,6 +509,7 @@ def test_start_simulate_dollar_volume_threshold_and_rank(
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
@@ -511,6 +563,7 @@ def test_start_simulate_supports_rsi_strategy(
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
@@ -568,6 +621,7 @@ def test_start_simulate_supports_slope_strategy(
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
@@ -625,6 +679,7 @@ def test_start_simulate_supports_slope_and_volume_strategy(
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
@@ -683,6 +738,7 @@ def test_start_simulate_supports_20_50_sma_cross_strategy(
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
@@ -737,6 +793,7 @@ def test_start_simulate_accepts_stop_loss_argument(
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
@@ -788,6 +845,7 @@ def test_start_simulate_accepts_cash_and_withdraw(
         sell_strategy_name: str,
         minimum_average_dollar_volume: float | None,
         top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,


### PR DESCRIPTION
## Summary
- allow `start_simulate` to accept `dollar_volume>N%` syntax
- filter symbols by market share of dollar volume during evaluation
- document percentage-based dollar volume usage and cover with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ae8fce2f30832bb8e0810cd315be71