### PR TITLE
Replace APR metric with CAGR

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -231,7 +231,7 @@ class StockShell(cmd.Cmd):
                 f"Holding period Std Dev: {evaluation_metrics.holding_period_standard_deviation:.2f} bars, "
                 f"Max concurrent positions: {evaluation_metrics.maximum_concurrent_positions}, "
                 f"Final balance: {evaluation_metrics.final_balance:.2f}, "
-                f"APR: {evaluation_metrics.apr:.2%}\n"
+                f"CAGR: {evaluation_metrics.compound_annual_growth_rate:.2%}\n"
             )
         )
         for year, annual_return in sorted(

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -69,7 +69,7 @@ class StrategyMetrics:
     holding_period_standard_deviation: float
     maximum_concurrent_positions: int
     final_balance: float
-    apr: float
+    compound_annual_growth_rate: float
     annual_returns: Dict[int, float]
     annual_trade_counts: Dict[int, int]
     trade_details_by_year: Dict[int, List[TradeDetail]] = field(default_factory=dict)
@@ -405,12 +405,12 @@ def calculate_metrics(
     holding_period_list: List[int],
     maximum_concurrent_positions: int = 0,
     final_balance: float = 0.0,
-    apr: float = 0.0,
+    compound_annual_growth_rate: float = 0.0,
     annual_returns: Dict[int, float] | None = None,
     annual_trade_counts: Dict[int, int] | None = None,
     trade_details_by_year: Dict[int, List[TradeDetail]] | None = None,
 ) -> StrategyMetrics:
-    """Compute summary metrics for a list of simulated trades, including APR."""
+    """Compute summary metrics for a list of simulated trades, including CAGR."""
     # TODO: review
 
     total_trades = len(trade_profit_list)
@@ -426,7 +426,7 @@ def calculate_metrics(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=maximum_concurrent_positions,
             final_balance=final_balance,
-            apr=apr,
+            compound_annual_growth_rate=compound_annual_growth_rate,
             annual_returns={} if annual_returns is None else annual_returns,
             annual_trade_counts={} if annual_trade_counts is None else annual_trade_counts,
             trade_details_by_year=
@@ -463,7 +463,7 @@ def calculate_metrics(
         ),
         maximum_concurrent_positions=maximum_concurrent_positions,
         final_balance=final_balance,
-        apr=apr,
+        compound_annual_growth_rate=compound_annual_growth_rate,
         annual_returns={} if annual_returns is None else annual_returns,
         annual_trade_counts={} if annual_trade_counts is None else annual_trade_counts,
         trade_details_by_year=
@@ -753,7 +753,7 @@ def evaluate_combined_strategy(
         )
     else:
         last_trade_exit_date = simulation_start_date
-    apr_value = 0.0
+    compound_annual_growth_rate_value = 0.0
     if (
         simulation_start_date is not None
         and last_trade_exit_date is not None
@@ -762,7 +762,7 @@ def evaluate_combined_strategy(
         duration_days = (last_trade_exit_date - simulation_start_date).days
         if duration_days > 0:
             duration_years = duration_days / 365.25
-            apr_value = (final_balance / starting_cash) ** (
+            compound_annual_growth_rate_value = (final_balance / starting_cash) ** (
                 1 / duration_years
             ) - 1
     for year_trades in trade_details_by_year.values():
@@ -774,7 +774,7 @@ def evaluate_combined_strategy(
         holding_period_list,
         maximum_concurrent_positions,
         final_balance,
-        apr_value,
+        compound_annual_growth_rate_value,
         annual_returns,
         annual_trade_counts,
         trade_details_by_year,
@@ -928,7 +928,7 @@ def evaluate_ema_sma_cross_strategy(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=maximum_concurrent_positions,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -961,7 +961,7 @@ def evaluate_ema_sma_cross_strategy(
         ),
         maximum_concurrent_positions=maximum_concurrent_positions,
         final_balance=0.0,
-        apr=0.0,
+        compound_annual_growth_rate=0.0,
         annual_returns={},
         annual_trade_counts={},
     )
@@ -1107,7 +1107,7 @@ def evaluate_kalman_channel_strategy(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=maximum_concurrent_positions,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -1142,7 +1142,7 @@ def evaluate_kalman_channel_strategy(
         ),
         maximum_concurrent_positions=maximum_concurrent_positions,
         final_balance=0.0,
-        apr=0.0,
+        compound_annual_growth_rate=0.0,
         annual_returns={},
         annual_trade_counts={},
     )

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -299,7 +299,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
             holding_period_standard_deviation=1.0,
             maximum_concurrent_positions=2,
             final_balance=123.45,
-            apr=0.1,
+            compound_annual_growth_rate=0.1,
             annual_returns={2023: 0.1, 2024: -0.05},
             annual_trade_counts={2023: 2, 2024: 1},
             trade_details_by_year=trade_details_by_year,
@@ -321,7 +321,8 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     assert (
         "Trades: 3, Win rate: 50.00%, Mean profit %: 10.00%, Profit % Std Dev: 0.00%, "
         "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "
-        "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2, Final balance: 123.45, APR: 10.00%" in output_buffer.getvalue()
+        "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2, Final balance: 123.45, CAGR: 10.00%"
+        in output_buffer.getvalue()
     )
     assert "Year 2023: 10.00%, trade: 2" in output_buffer.getvalue()
     assert "Year 2024: -5.00%, trade: 1" in output_buffer.getvalue()
@@ -380,7 +381,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -434,7 +435,7 @@ def test_start_simulate_dollar_volume_rank(monkeypatch: pytest.MonkeyPatch) -> N
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -481,7 +482,7 @@ def test_start_simulate_dollar_volume_ratio(monkeypatch: pytest.MonkeyPatch) -> 
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -533,7 +534,7 @@ def test_start_simulate_dollar_volume_threshold_and_rank(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -587,7 +588,7 @@ def test_start_simulate_supports_rsi_strategy(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -646,7 +647,7 @@ def test_start_simulate_supports_slope_strategy(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -705,7 +706,7 @@ def test_start_simulate_supports_slope_and_volume_strategy(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -765,7 +766,7 @@ def test_start_simulate_supports_20_50_sma_cross_strategy(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -821,7 +822,7 @@ def test_start_simulate_accepts_stop_loss_argument(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )
@@ -873,7 +874,7 @@ def test_start_simulate_accepts_cash_and_withdraw(
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
             final_balance=0.0,
-            apr=0.0,
+            compound_annual_growth_rate=0.0,
             annual_returns={},
             annual_trade_counts={},
         )

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -397,16 +397,16 @@ def test_evaluate_combined_strategy_different_names(
     assert result.win_rate == 0.5
 
 
-def test_evaluate_combined_strategy_calculates_apr(
+def test_evaluate_combined_strategy_calculates_compound_annual_growth_rate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The function should compute APR based on final balance and duration."""
+    """The function should compute CAGR based on final balance and duration."""
 
     date_index = pandas.date_range("2020-01-01", periods=370, freq="D")
     price_data_frame = pandas.DataFrame(
         {"Date": date_index, "open": [10.0] * 370, "close": [10.0] * 370}
     )
-    csv_path = tmp_path / "apr_test.csv"
+    csv_path = tmp_path / "cagr_test.csv"
     price_data_frame.to_csv(csv_path, index=False)
 
     trade = Trade(
@@ -435,8 +435,10 @@ def test_evaluate_combined_strategy_calculates_apr(
     result = evaluate_combined_strategy(tmp_path, "ema_sma_cross", "ema_sma_cross")
 
     duration_years = (trade.exit_date - trade.entry_date).days / 365.25
-    expected_apr = (3300.0 / 3000.0) ** (1 / duration_years) - 1
-    assert result.apr == pytest.approx(expected_apr)
+    expected_growth_rate = (3300.0 / 3000.0) ** (1 / duration_years) - 1
+    assert result.compound_annual_growth_rate == pytest.approx(
+        expected_growth_rate
+    )
 
 
 def test_evaluate_combined_strategy_unsupported_name(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- replace APR with compound annual growth rate (CAGR) throughout strategy metrics
- compute compound annual growth rate during combined strategy evaluation
- display CAGR after final balance in simulation output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aeab9675ec832bb7cdff43bef563e6