### PR TITLE
Add maximum drawdown metric to strategy evaluations

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -37,6 +37,9 @@ with the highest remaining averages. The tests
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 exercise this combined syntax.
 
+The simulation report lists the maximum drawdown alongside other metrics. This
+percentage indicates the greatest decline from any previous portfolio peak.
+
 The previous `start_ftd_ema_sma_cross` command has been removed.
 Use `start_simulate` with `ftd_ema_sma_cross` for both the buying and
 selling strategies instead.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ selects the six highest-volume symbols from the remainder. The tests
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 demonstrate this combined syntax.
 
+The summary printed after each simulation includes the maximum drawdown. This
+value represents the largest peak-to-trough decline in portfolio value over the
+test period and is expressed as a percentage.
+
 To express the threshold as a percentage of total market dollar volume, use a
 percent sign. For example `dollar_volume>1%` retains only symbols whose
 50-day average dollar volume is greater than one percent of the combined

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -231,7 +231,8 @@ class StockShell(cmd.Cmd):
                 f"Holding period Std Dev: {evaluation_metrics.holding_period_standard_deviation:.2f} bars, "
                 f"Max concurrent positions: {evaluation_metrics.maximum_concurrent_positions}, "
                 f"Final balance: {evaluation_metrics.final_balance:.2f}, "
-                f"CAGR: {evaluation_metrics.compound_annual_growth_rate:.2%}\n"
+                f"CAGR: {evaluation_metrics.compound_annual_growth_rate:.2%}, "
+                f"Max drawdown: {evaluation_metrics.maximum_drawdown:.2%}\n"
             )
         )
         for year, annual_return in sorted(

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -18,6 +18,7 @@ from .simulator import (
     calculate_annual_returns,
     calculate_annual_trade_counts,
     calculate_maximum_concurrent_positions,
+    calculate_max_drawdown,
     simulate_portfolio_balance,
     simulate_trades,
 )
@@ -68,6 +69,7 @@ class StrategyMetrics:
     mean_holding_period: float
     holding_period_standard_deviation: float
     maximum_concurrent_positions: int
+    maximum_drawdown: float
     final_balance: float
     compound_annual_growth_rate: float
     annual_returns: Dict[int, float]
@@ -404,6 +406,7 @@ def calculate_metrics(
     loss_percentage_list: List[float],
     holding_period_list: List[int],
     maximum_concurrent_positions: int = 0,
+    maximum_drawdown: float = 0.0,
     final_balance: float = 0.0,
     compound_annual_growth_rate: float = 0.0,
     annual_returns: Dict[int, float] | None = None,
@@ -425,6 +428,7 @@ def calculate_metrics(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=maximum_concurrent_positions,
+            maximum_drawdown=maximum_drawdown,
             final_balance=final_balance,
             compound_annual_growth_rate=compound_annual_growth_rate,
             annual_returns={} if annual_returns is None else annual_returns,
@@ -462,6 +466,7 @@ def calculate_metrics(
             [float(value) for value in holding_period_list]
         ),
         maximum_concurrent_positions=maximum_concurrent_positions,
+        maximum_drawdown=maximum_drawdown,
         final_balance=final_balance,
         compound_annual_growth_rate=compound_annual_growth_rate,
         annual_returns={} if annual_returns is None else annual_returns,
@@ -747,6 +752,9 @@ def evaluate_combined_strategy(
     final_balance = simulate_portfolio_balance(
         all_trades, starting_cash, eligible_symbol_counts_by_date, withdraw_amount
     )
+    maximum_drawdown = calculate_max_drawdown(
+        all_trades, starting_cash, eligible_symbol_counts_by_date, withdraw_amount
+    )
     if all_trades:
         last_trade_exit_date = max(
             completed_trade.exit_date for completed_trade in all_trades
@@ -770,9 +778,10 @@ def evaluate_combined_strategy(
     return calculate_metrics(
         trade_profit_list,
         profit_percentage_list,
-        loss_percentage_list,
+       loss_percentage_list,
         holding_period_list,
         maximum_concurrent_positions,
+        maximum_drawdown,
         final_balance,
         compound_annual_growth_rate_value,
         annual_returns,
@@ -927,6 +936,7 @@ def evaluate_ema_sma_cross_strategy(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=maximum_concurrent_positions,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -960,6 +970,7 @@ def evaluate_ema_sma_cross_strategy(
             [float(value) for value in holding_period_list]
         ),
         maximum_concurrent_positions=maximum_concurrent_positions,
+        maximum_drawdown=0.0,
         final_balance=0.0,
         compound_annual_growth_rate=0.0,
         annual_returns={},
@@ -1106,6 +1117,7 @@ def evaluate_kalman_channel_strategy(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=maximum_concurrent_positions,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -1141,6 +1153,7 @@ def evaluate_kalman_channel_strategy(
             [float(value) for value in holding_period_list]
         ),
         maximum_concurrent_positions=maximum_concurrent_positions,
+        maximum_drawdown=0.0,
         final_balance=0.0,
         compound_annual_growth_rate=0.0,
         annual_returns={},

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -298,6 +298,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
             mean_holding_period=2.0,
             holding_period_standard_deviation=1.0,
             maximum_concurrent_positions=2,
+            maximum_drawdown=0.25,
             final_balance=123.45,
             compound_annual_growth_rate=0.1,
             annual_returns={2023: 0.1, 2024: -0.05},
@@ -321,7 +322,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     assert (
         "Trades: 3, Win rate: 50.00%, Mean profit %: 10.00%, Profit % Std Dev: 0.00%, "
         "Mean loss %: 5.00%, Loss % Std Dev: 0.00%, Mean holding period: 2.00 bars, "
-        "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2, Final balance: 123.45, CAGR: 10.00%"
+        "Holding period Std Dev: 1.00 bars, Max concurrent positions: 2, Final balance: 123.45, CAGR: 10.00%, Max drawdown: 25.00%"
         in output_buffer.getvalue()
     )
     assert "Year 2023: 10.00%, trade: 2" in output_buffer.getvalue()
@@ -380,6 +381,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -434,6 +436,7 @@ def test_start_simulate_dollar_volume_rank(monkeypatch: pytest.MonkeyPatch) -> N
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -481,6 +484,7 @@ def test_start_simulate_dollar_volume_ratio(monkeypatch: pytest.MonkeyPatch) -> 
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -533,6 +537,7 @@ def test_start_simulate_dollar_volume_threshold_and_rank(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -587,6 +592,7 @@ def test_start_simulate_supports_rsi_strategy(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -646,6 +652,7 @@ def test_start_simulate_supports_slope_strategy(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -705,6 +712,7 @@ def test_start_simulate_supports_slope_and_volume_strategy(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -765,6 +773,7 @@ def test_start_simulate_supports_20_50_sma_cross_strategy(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -821,6 +830,7 @@ def test_start_simulate_accepts_stop_loss_argument(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},
@@ -873,6 +883,7 @@ def test_start_simulate_accepts_cash_and_withdraw(
             mean_holding_period=0.0,
             holding_period_standard_deviation=0.0,
             maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
             final_balance=0.0,
             compound_annual_growth_rate=0.0,
             annual_returns={},


### PR DESCRIPTION
## Summary
- track daily portfolio value and expose `calculate_max_drawdown`
- record drawdowns in `StrategyMetrics` and CLI output
- document drawdown metric and add regression tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aeb27acce4832b905b2f05394885a0