### PR TITLE
feat: allow simulation start date override

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -110,19 +110,29 @@ class StockShell(cmd.Cmd):
 
     # TODO: review
     def do_start_simulate(self, argument_line: str) -> None:  # noqa: D401
-        """start_simulate [starting_cash=NUMBER] [withdraw=NUMBER] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]
+        """start_simulate [starting_cash=NUMBER] [withdraw=NUMBER] [start=YYYY-MM-DD] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]
         Evaluate trading strategies using cached data.
 
         STOP_LOSS defaults to 1.0 when not provided."""
         argument_parts: List[str] = argument_line.split()
         starting_cash_value = 3000.0
         withdraw_amount = 0.0
+        start_date_string: str | None = None
         while argument_parts and (
             argument_parts[0].startswith("starting_cash=")
             or argument_parts[0].startswith("withdraw=")
+            or argument_parts[0].startswith("start=")
         ):
             parameter_part = argument_parts.pop(0)
             name, value = parameter_part.split("=", 1)
+            if name == "start":
+                try:
+                    datetime.date.fromisoformat(value)
+                except ValueError:
+                    self.stdout.write("invalid start date\n")
+                    return
+                start_date_string = value
+                continue
             try:
                 numeric_value = float(value)
             except ValueError:
@@ -134,7 +144,7 @@ class StockShell(cmd.Cmd):
                 withdraw_amount = numeric_value
         if len(argument_parts) not in (3, 4):
             self.stdout.write(
-                "usage: start_simulate [starting_cash=NUMBER] [withdraw=NUMBER] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]\n"
+                "usage: start_simulate [starting_cash=NUMBER] [withdraw=NUMBER] [start=YYYY-MM-DD] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]\n"
             )
             return
         volume_filter, buy_strategy_name, sell_strategy_name = argument_parts[:3]
@@ -204,7 +214,8 @@ class StockShell(cmd.Cmd):
             self.stdout.write("unsupported strategies\n")
             return
 
-        start_date_string = determine_start_date(DATA_DIRECTORY)
+        if start_date_string is None:
+            start_date_string = determine_start_date(DATA_DIRECTORY)
         evaluation_metrics = strategy.evaluate_combined_strategy(
             DATA_DIRECTORY,
             buy_strategy_name,
@@ -215,6 +226,7 @@ class StockShell(cmd.Cmd):
             starting_cash=starting_cash_value,
             withdraw_amount=withdraw_amount,
             stop_loss_percentage=stop_loss_percentage,
+            start_date=start_date_string,
         )
         self.stdout.write(
             f"Simulation start date: {start_date_string}\n"
@@ -274,11 +286,12 @@ class StockShell(cmd.Cmd):
         available_buy = ", ".join(sorted(strategy.BUY_STRATEGIES.keys()))
         available_sell = ", ".join(sorted(strategy.SELL_STRATEGIES.keys()))
         self.stdout.write(
-            "start_simulate [starting_cash=NUMBER] [withdraw=NUMBER] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]\n"
+            "start_simulate [starting_cash=NUMBER] [withdraw=NUMBER] [start=YYYY-MM-DD] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]\n"
             "Evaluate trading strategies using cached data.\n"
             "Parameters:\n"
             "  starting_cash: Initial cash balance for the simulation. Defaults to 3000.\n"
             "  withdraw: Amount deducted from cash at each year end. Defaults to 0.\n"
+            "  start: Date in YYYY-MM-DD format to begin the simulation. Defaults to the earliest available date.\n"
             "  DOLLAR_VOLUME_FILTER: Use dollar_volume>NUMBER (in millions),\n"
             "    dollar_volume>N% to require the 50-day average dollar volume to\n"
             "    exceed N percent of the total market, dollar_volume=Nth to\n"

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -213,6 +213,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         call_record["strategies"] = (buy_strategy_name, sell_strategy_name)
         volume_record["threshold"] = minimum_average_dollar_volume
@@ -365,6 +366,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         call_arguments["strategies"] = (buy_strategy_name, sell_strategy_name)
         threshold_record["threshold"] = minimum_average_dollar_volume
@@ -422,6 +424,7 @@ def test_start_simulate_dollar_volume_rank(monkeypatch: pytest.MonkeyPatch) -> N
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         rank_record["rank"] = top_dollar_volume_rank
         assert starting_cash == 3000.0
@@ -472,6 +475,7 @@ def test_start_simulate_dollar_volume_ratio(monkeypatch: pytest.MonkeyPatch) -> 
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         ratio_record["ratio"] = minimum_average_dollar_volume_ratio
         return StrategyMetrics(
@@ -522,6 +526,7 @@ def test_start_simulate_dollar_volume_threshold_and_rank(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         recorded_values["threshold"] = minimum_average_dollar_volume
         recorded_values["rank"] = top_dollar_volume_rank
@@ -578,6 +583,7 @@ def test_start_simulate_supports_rsi_strategy(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         call_arguments["strategies"] = (buy_strategy_name, sell_strategy_name)
         assert starting_cash == 3000.0
@@ -638,6 +644,7 @@ def test_start_simulate_supports_slope_strategy(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         call_arguments["strategies"] = (buy_strategy_name, sell_strategy_name)
         assert starting_cash == 3000.0
@@ -698,6 +705,7 @@ def test_start_simulate_supports_slope_and_volume_strategy(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         call_arguments["strategies"] = (buy_strategy_name, sell_strategy_name)
         assert starting_cash == 3000.0
@@ -759,6 +767,7 @@ def test_start_simulate_supports_20_50_sma_cross_strategy(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         call_arguments["strategies"] = (buy_strategy_name, sell_strategy_name)
         assert starting_cash == 3000.0
@@ -816,6 +825,7 @@ def test_start_simulate_accepts_stop_loss_argument(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         stop_loss_record["value"] = stop_loss_percentage
         assert starting_cash == 3000.0
@@ -870,6 +880,7 @@ def test_start_simulate_accepts_cash_and_withdraw(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
     ) -> StrategyMetrics:
         recorded_values["cash"] = starting_cash
         recorded_values["withdraw"] = withdraw_amount

--- a/tests/test_start_simulate_start_date.py
+++ b/tests/test_start_simulate_start_date.py
@@ -1,0 +1,70 @@
+"""Tests for start date handling in the ``start_simulate`` command."""
+
+# TODO: review
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+import stock_indicator.manage as manage_module
+import stock_indicator.strategy as strategy_module
+from stock_indicator.strategy import StrategyMetrics
+
+
+def test_start_simulate_accepts_start_date(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``start_simulate`` should pass the supplied start date to evaluation."""
+
+    recorded_arguments: dict[str, str | None] = {"start_date": None}
+    start_date_called: dict[str, bool] = {"called": False}
+
+    def fake_determine_start_date(data_directory: Path) -> str:  # pragma: no cover - defensive
+        start_date_called["called"] = True
+        return "1900-01-01"
+
+    def fake_evaluate_combined_strategy(
+        data_directory: Path,
+        buy_strategy_name: str,
+        sell_strategy_name: str,
+        minimum_average_dollar_volume: float | None,
+        top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
+        starting_cash: float = 3000.0,
+        withdraw_amount: float = 0.0,
+        stop_loss_percentage: float = 1.0,
+        start_date: str | None = None,
+    ) -> StrategyMetrics:
+        recorded_arguments["start_date"] = start_date
+        return StrategyMetrics(
+            total_trades=0,
+            win_rate=0.0,
+            mean_profit_percentage=0.0,
+            profit_percentage_standard_deviation=0.0,
+            mean_loss_percentage=0.0,
+            loss_percentage_standard_deviation=0.0,
+            mean_holding_period=0.0,
+            holding_period_standard_deviation=0.0,
+            maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
+            final_balance=0.0,
+            compound_annual_growth_rate=0.0,
+            annual_returns={},
+            annual_trade_counts={},
+        )
+
+    monkeypatch.setattr(manage_module, "determine_start_date", fake_determine_start_date)
+    monkeypatch.setattr(strategy_module, "evaluate_combined_strategy", fake_evaluate_combined_strategy)
+    monkeypatch.setattr(strategy_module, "BUY_STRATEGIES", {"noop": lambda frame: None})
+    monkeypatch.setattr(strategy_module, "SELL_STRATEGIES", {"noop": lambda frame: None})
+    monkeypatch.setattr(manage_module, "DATA_DIRECTORY", tmp_path)
+
+    output_buffer = io.StringIO()
+    shell = manage_module.StockShell(stdout=output_buffer)
+    shell.onecmd("start_simulate start=2020-05-06 dollar_volume>0 noop noop")
+
+    assert recorded_arguments["start_date"] == "2020-05-06"
+    assert start_date_called["called"] is False
+    assert "Simulation start date: 2020-05-06" in output_buffer.getvalue()
+


### PR DESCRIPTION
## Summary
- support `start=YYYY-MM-DD` in `start_simulate`
- allow strategies to begin at a specified date
- document new parameter and expand tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aec1482eb8832b9f9474aa7943bcef