### PR TITLE
Add tests for start date handling in simulation and evaluation

### DIFF
--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -406,6 +406,59 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
     assert stop_loss_record["value"] == 1.0
 
 
+def test_start_simulate_accepts_start_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The command should forward the start date to evaluation."""
+    import stock_indicator.manage as manage_module
+
+    recorded_arguments: dict[str, pandas.Timestamp | None] = {}
+
+    from stock_indicator.strategy import StrategyMetrics
+
+    def fake_evaluate(
+        data_directory: Path,
+        buy_strategy_name: str,
+        sell_strategy_name: str,
+        minimum_average_dollar_volume: float | None,
+        top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
+        starting_cash: float = 3000.0,
+        withdraw_amount: float = 0.0,
+        stop_loss_percentage: float = 1.0,
+        start_date: pandas.Timestamp | None = None,
+    ) -> StrategyMetrics:
+        recorded_arguments["start_date"] = start_date
+        return StrategyMetrics(
+            total_trades=0,
+            win_rate=0.0,
+            mean_profit_percentage=0.0,
+            profit_percentage_standard_deviation=0.0,
+            mean_loss_percentage=0.0,
+            loss_percentage_standard_deviation=0.0,
+            mean_holding_period=0.0,
+            holding_period_standard_deviation=0.0,
+            maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
+            final_balance=0.0,
+            compound_annual_growth_rate=0.0,
+            annual_returns={},
+            annual_trade_counts={},
+        )
+
+    monkeypatch.setattr(
+        manage_module.strategy,
+        "evaluate_combined_strategy",
+        fake_evaluate,
+    )
+
+    output_buffer = io.StringIO()
+    shell = manage_module.StockShell(stdout=output_buffer)
+    shell.onecmd(
+        "start_simulate start=2018-01-01 dollar_volume>0 ema_sma_cross ema_sma_cross"
+    )
+    assert recorded_arguments["start_date"] == pandas.Timestamp("2018-01-01")
+    assert "Simulation start date: 2018-01-01" in output_buffer.getvalue()
+
+
 def test_start_simulate_dollar_volume_rank(monkeypatch: pytest.MonkeyPatch) -> None:
     """The command should forward the ranking filter to evaluation."""
     import stock_indicator.manage as manage_module


### PR DESCRIPTION
## Summary
- add CLI test ensuring `start_simulate` forwards `start` argument to evaluator
- cover strategy evaluation filtering to ignore trades prior to `start_date`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aec568e748832b94d6d4006209db4f