### PR TITLE
Support percentage dollar volume filters

### DIFF
--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -156,8 +156,10 @@ def main() -> None:
         "argument_line",
         help=(
             "Task description: 'dollar_volume>NUMBER BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]', "
-            "'dollar_volume=RANKth BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]', or "
-            "'dollar_volume>NUMBER,RANKth BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]'"
+            "'dollar_volume>NUMBER% BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]', "
+            "'dollar_volume=RANKth BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]', "
+            "'dollar_volume>NUMBER,RANKth BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]', or "
+            "'dollar_volume>NUMBER%,RANKth BUY_STRATEGY SELL_STRATEGY [STOP_LOSS]'"
         ),
     )
     parsed_arguments = parser.parse_args()

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -96,6 +96,40 @@ def test_parse_daily_task_arguments_accepts_threshold_and_rank() -> None:
     assert stop_loss_percentage == 1.0
 
 
+def test_parse_daily_task_arguments_accepts_percentage() -> None:
+    """The parser should accept percentage-based dollar volume filters."""
+    argument_line = "dollar_volume>2.41% ema_sma_cross ema_sma_cross"
+    (
+        minimum_average_dollar_volume,
+        top_dollar_volume_rank,
+        buy_strategy_name,
+        sell_strategy_name,
+        stop_loss_percentage,
+    ) = cron.parse_daily_task_arguments(argument_line)
+    assert minimum_average_dollar_volume == pytest.approx(0.0241)
+    assert top_dollar_volume_rank is None
+    assert buy_strategy_name == "ema_sma_cross"
+    assert sell_strategy_name == "ema_sma_cross"
+    assert stop_loss_percentage == 1.0
+
+
+def test_parse_daily_task_arguments_accepts_percentage_and_rank() -> None:
+    """The parser should accept percentage filters combined with ranking."""
+    argument_line = "dollar_volume>2.41%,5th ema_sma_cross ema_sma_cross"
+    (
+        minimum_average_dollar_volume,
+        top_dollar_volume_rank,
+        buy_strategy_name,
+        sell_strategy_name,
+        stop_loss_percentage,
+    ) = cron.parse_daily_task_arguments(argument_line)
+    assert minimum_average_dollar_volume == pytest.approx(0.0241)
+    assert top_dollar_volume_rank == 5
+    assert buy_strategy_name == "ema_sma_cross"
+    assert sell_strategy_name == "ema_sma_cross"
+    assert stop_loss_percentage == 1.0
+
+
 def test_run_daily_tasks_skips_symbol_update_errors(monkeypatch):
     """run_daily_tasks should continue when the symbol cache update fails."""
 


### PR DESCRIPTION
## Summary
- allow `parse_daily_task_arguments` to recognize dollar volume filters using percentage syntax
- document and expose percentage-based filters in `daily_job` CLI
- test percentage parsing for cron arguments and daily job runner

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aefb741e14832b8d9b9939c71a9860