### PR TITLE
Allow windowed strategy names in start_simulate

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -208,10 +208,16 @@ class StockShell(cmd.Cmd):
                                 "dollar_volume>NUMBER%,RANKth\n",
                             )
                             return
-        if buy_strategy_name not in strategy.BUY_STRATEGIES:
+        try:  # TODO: review
+            buy_base_name, _ = strategy.parse_strategy_name(buy_strategy_name)
+            sell_base_name, _ = strategy.parse_strategy_name(sell_strategy_name)
+        except ValueError:
             self.stdout.write("unsupported strategies\n")
             return
-        if sell_strategy_name not in strategy.SELL_STRATEGIES:
+        if (
+            buy_base_name not in strategy.BUY_STRATEGIES
+            or sell_base_name not in strategy.SELL_STRATEGIES
+        ):
             self.stdout.write("unsupported strategies\n")
             return
 


### PR DESCRIPTION
## Summary
- Parse strategy names in `start_simulate` using `parse_strategy_name`
- Validate parsed strategy bases and report unsupported combinations
- Add regression test covering windowed strategy names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af01bb01d0832ba7c305552a1e4789