### PR TITLE
Document strategy window-size suffix

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -309,6 +309,8 @@ class StockShell(cmd.Cmd):
             "  BUY_STRATEGY: Name of the buying strategy.\n"
             "  SELL_STRATEGY: Name of the selling strategy.\n"
             "  STOP_LOSS: Fractional loss that triggers an exit on the next day's open. Defaults to 1.0.\n"
+            "Strategies may be suffixed with _N to set the window size to N; the default window size is 50 when no suffix is provided.\n"
+            "Example: start_simulate start=1990-01-01 dollar_volume>50 ema_sma_cross_20 ema_sma_cross_20\n"
             f"Available buy strategies: {available_buy}.\n"
             f"Available sell strategies: {available_sell}.\n"
         )


### PR DESCRIPTION
## Summary
- Mention that strategies can be suffixed with `_N` to set the window size, defaulting to 50
- Provide an example `start_simulate` command using a suffixed strategy name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68af04797388832b976d7c92d789e5c2