### PR TITLE
Adjust EMA/SMA cross strategy window defaults to 40 days

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -78,13 +78,13 @@ The `start_simulate` command accepts the following strategies:
 * `20_50_sma_cross`
 * `ema_sma_cross_and_rsi`
 * `ftd_ema_sma_cross`
-* `ema_sma_cross_with_slope` *(use `ema_sma_cross_with_slope_N` to set a custom EMA/SMA window size; `N` defaults to 50)*
+* `ema_sma_cross_with_slope` *(use `ema_sma_cross_with_slope_N` to set a custom EMA/SMA window size; `N` defaults to 40)*
 * `ema_sma_cross_with_slope_and_volume`
 * `ema_sma_double_cross`
 * `kalman_filtering` *(sell only)*
 
 To change the EMA and SMA window size, append `_N` to `ema_sma_cross_with_slope`,
-where `N` sets the number of days and defaults to `50`:
+where `N` sets the number of days and defaults to `40`:
 
 ```
 start_simulate dollar_volume>1 ema_sma_cross_with_slope_40 ema_sma_cross_with_slope_40

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -309,7 +309,7 @@ class StockShell(cmd.Cmd):
             "  BUY_STRATEGY: Name of the buying strategy.\n"
             "  SELL_STRATEGY: Name of the selling strategy.\n"
             "  STOP_LOSS: Fractional loss that triggers an exit on the next day's open. Defaults to 1.0.\n"
-            "Strategies may be suffixed with _N to set the window size to N; the default window size is 50 when no suffix is provided.\n"
+            "Strategies may be suffixed with _N to set the window size to N; the default window size is 40 when no suffix is provided.\n"
             "Example: start_simulate start=1990-01-01 dollar_volume>50 ema_sma_cross_20 ema_sma_cross_20\n"
             f"Available buy strategies: {available_buy}.\n"
             f"Available sell strategies: {available_sell}.\n"

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -126,7 +126,7 @@ def load_price_data(csv_file_path: Path) -> pandas.DataFrame:
 
 def attach_ema_sma_cross_signals(
     price_data_frame: pandas.DataFrame,
-    window_size: int = 50,
+    window_size: int = 40,
     require_close_above_long_term_sma: bool = True,
 ) -> None:
     """Attach EMA/SMA cross entry and exit signals to ``price_data_frame``.
@@ -204,7 +204,7 @@ def attach_20_50_sma_cross_signals(price_data_frame: pandas.DataFrame) -> None:
 
 def attach_ema_sma_cross_and_rsi_signals(
     price_data_frame: pandas.DataFrame,
-    window_size: int = 50,
+    window_size: int = 40,
     rsi_window_size: int = 14,
 ) -> None:
     """Attach EMA/SMA cross signals filtered by RSI to ``price_data_frame``."""
@@ -224,7 +224,7 @@ def attach_ema_sma_cross_and_rsi_signals(
 
 
 def attach_ftd_ema_sma_cross_signals(
-    price_data_frame: pandas.DataFrame, window_size: int = 50
+    price_data_frame: pandas.DataFrame, window_size: int = 40
 ) -> None:
     """Attach EMA/SMA cross signals gated by recent FTD signals."""
     # TODO: review
@@ -251,7 +251,7 @@ def attach_ftd_ema_sma_cross_signals(
 
 def attach_ema_sma_cross_with_slope_signals(
     price_data_frame: pandas.DataFrame,
-    window_size: int = 50,
+    window_size: int = 40,
     slope_range: tuple[float, float] = (-0.3, 1.0),
 ) -> None:
     """Attach EMA/SMA cross signals filtered by SMA slope to ``price_data_frame``.
@@ -285,7 +285,7 @@ def attach_ema_sma_cross_with_slope_signals(
 
 def attach_ema_sma_cross_with_slope_and_volume_signals(
     price_data_frame: pandas.DataFrame,
-    window_size: int = 50,
+    window_size: int = 40,
     slope_range: tuple[float, float] = (-0.3, 1.0),
 ) -> None:
     """Attach EMA/SMA cross signals filtered by SMA slope and dollar volume."""
@@ -317,7 +317,7 @@ def attach_ema_sma_cross_with_slope_and_volume_signals(
 
 def attach_ema_sma_double_cross_signals(
     price_data_frame: pandas.DataFrame,
-    window_size: int = 50,
+    window_size: int = 40,
 ) -> None:
     """Attach EMA/SMA cross signals requiring long-term EMA above SMA."""
     # TODO: review


### PR DESCRIPTION
## Summary
- default EMA/SMA window size reduced from 50 to 40 days across cross-based strategies
- update CLI help and usage docs to note the new 40‑day default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af251481b0832baffbd09b2dc79947