### PR TITLE
Document slope-bound strategy naming and update CLI help

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -78,16 +78,27 @@ The `start_simulate` command accepts the following strategies:
 * `20_50_sma_cross`
 * `ema_sma_cross_and_rsi`
 * `ftd_ema_sma_cross`
-* `ema_sma_cross_with_slope` *(use `ema_sma_cross_with_slope_N` to set a custom EMA/SMA window size; `N` defaults to 40)*
+* `ema_sma_cross_with_slope` *(use `ema_sma_cross_with_slope_N` to set a custom EMA/SMA window size; `N` defaults to 40. Append `_LOWER_UPPER` to constrain the simple moving average slope to a range.)*
 * `ema_sma_cross_with_slope_and_volume`
 * `ema_sma_double_cross`
 * `kalman_filtering` *(sell only)*
 
-To change the EMA and SMA window size, append `_N` to `ema_sma_cross_with_slope`,
-where `N` sets the number of days and defaults to `40`:
+To change the EMA and SMA window size, append `_N` to `ema_sma_cross_with_slope`, where `N` sets the number of days and defaults to `40`:
 
 ```
 start_simulate dollar_volume>1 ema_sma_cross_with_slope_40 ema_sma_cross_with_slope_40
+```
+
+To limit the slope of the simple moving average, add two numeric bounds after the optional window size. Both bounds may be negative or positive floating-point numbers. These strategies follow the generic `ema_sma_signal_with_slope_n_k` pattern and use the format `ema_sma_cross_with_slope[_N]_LOWER_UPPER`:
+
+```
+start_simulate dollar_volume>1 ema_sma_cross_with_slope_-0.1_1.2 ema_sma_cross_with_slope_-0.1_1.2
+```
+
+The window size and slope range can be combined by placing the integer before the slope bounds:
+
+```
+start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-0.1_1.2 ema_sma_cross_with_slope_40_-0.1_1.2
 ```
 
 Not every strategy supports both buying and selling. Only the first seven

--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ selects the six highest-volume symbols from the remainder. The tests
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 demonstrate this combined syntax.
 
+Strategies may also limit the simple moving average slope. These identifiers follow the `ema_sma_signal_with_slope_n_k` pattern where `n` and `k` are the lower and upper slope bounds. The bounds accept negative or positive floating-point numbers. For example:
+
+```bash
+(stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_with_slope_-0.1_1.2 ema_sma_cross_with_slope_-0.1_1.2
+```
+
+You can combine slope bounds with a custom EMA/SMA window size by placing the integer before the bounds:
+
+```bash
+(stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-0.1_1.2 ema_sma_cross_with_slope_40_-0.1_1.2
+```
+
+When omitted, the window size defaults to 40 days.
+
 The summary printed after each simulation includes the maximum drawdown. This
 value represents the largest peak-to-trough decline in portfolio value over the
 test period and is expressed as a percentage.

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -310,7 +310,9 @@ class StockShell(cmd.Cmd):
             "  SELL_STRATEGY: Name of the selling strategy.\n"
             "  STOP_LOSS: Fractional loss that triggers an exit on the next day's open. Defaults to 1.0.\n"
             "Strategies may be suffixed with _N to set the window size to N; the default window size is 40 when no suffix is provided.\n"
+            "Slope-aware strategies follow the ema_sma_signal_with_slope_n_k pattern and accept _LOWER_UPPER bounds after the optional window size; bounds may be negative or positive floats.\n"
             "Example: start_simulate start=1990-01-01 dollar_volume>50 ema_sma_cross_20 ema_sma_cross_20\n"
+            "Another example: start_simulate dollar_volume>1 ema_sma_cross_with_slope_-0.1_1.2 ema_sma_cross_with_slope_-0.1_1.2\n"
             f"Available buy strategies: {available_buy}.\n"
             f"Available sell strategies: {available_sell}.\n"
         )


### PR DESCRIPTION
## Summary
- Document `ema_sma_signal_with_slope_n_k`-style strategy names and slope ranges in Docs/Usage and README
- Note that slope bounds may be negative or positive floats and can follow optional window sizes
- Expand CLI help to mention slope-range suffixes alongside window-size suffixes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af2cbea270832b8da67934df5fc100