### PR TITLE
docs: reference slope range tests

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -101,6 +101,8 @@ The window size and slope range can be combined by placing the integer before th
 start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-0.1_1.2 ema_sma_cross_with_slope_40_-0.1_1.2
 ```
 
+The tests `tests/test_manage.py::test_start_simulate_accepts_slope_range_strategy_names` and `tests/test_strategy.py::test_evaluate_combined_strategy_passes_slope_range` confirm this behavior. The management test shows the command accepts strategy names with slope bounds, and the strategy test verifies that the evaluation routine passes the bounds to the strategy implementation.
+
 Not every strategy supports both buying and selling. Only the first seven
 strategies in the list can be used for buying. All eight strategies can be
 used for selling.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ You can combine slope bounds with a custom EMA/SMA window size by placing the in
 
 When omitted, the window size defaults to 40 days.
 
+The tests `tests/test_manage.py::test_start_simulate_accepts_slope_range_strategy_names` and `tests/test_strategy.py::test_evaluate_combined_strategy_passes_slope_range` demonstrate the slope-bound syntax. The former shows that `start_simulate` recognizes strategy identifiers with slope ranges, while the latter verifies that the evaluation function passes the provided bounds to the strategy implementation.
+
 The summary printed after each simulation includes the maximum drawdown. This
 value represents the largest peak-to-trough decline in portfolio value over the
 test period and is expressed as a percentage.


### PR DESCRIPTION
## Summary
- Document slope-range strategy test coverage in README and usage guide
- Explain what each referenced test verifies about slope-bound syntax

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af3981ba78832bbe63b0b1f94b2f5e