### PR TITLE
Implement slot-based position sizing and tests

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -634,6 +634,7 @@ def evaluate_combined_strategy(
     withdraw_amount: float = 0.0,
     stop_loss_percentage: float = 1.0,
     start_date: pandas.Timestamp | None = None,
+    maximum_position_count: int = 3,
 ) -> StrategyMetrics:
     """Evaluate a combination of strategies for entry and exit signals.
 
@@ -677,6 +678,9 @@ def evaluate_combined_strategy(
         rows on or after this date before any signals are calculated. The
         simulation begins on the later of ``start_date`` and the earliest date
         on which a symbol becomes eligible.
+    maximum_position_count: int, default 3
+        Upper bound on the number of simultaneous open positions. Each
+        position uses a fixed fraction of equity based on this limit.
     """
     # TODO: review
 
@@ -781,9 +785,6 @@ def evaluate_combined_strategy(
         merged_volume_frame = pandas.DataFrame()
         eligibility_mask = pandas.DataFrame()
 
-    eligible_symbol_counts_by_date = (
-        eligibility_mask.sum(axis=1).astype(int).to_dict()
-    )
     market_total_dollar_volume_by_date = (
         merged_volume_frame.sum(axis=1).to_dict()
     )
@@ -963,18 +964,18 @@ def evaluate_combined_strategy(
     annual_returns = calculate_annual_returns(
         all_trades,
         starting_cash,
-        eligible_symbol_counts_by_date,
+        maximum_position_count,
         simulation_start_date,
         withdraw_amount,
     )
     annual_trade_counts = calculate_annual_trade_counts(all_trades)
     final_balance = simulate_portfolio_balance(
-        all_trades, starting_cash, eligible_symbol_counts_by_date, withdraw_amount
+        all_trades, starting_cash, maximum_position_count, withdraw_amount
     )
     maximum_drawdown = calculate_max_drawdown(
         all_trades,
         starting_cash,
-        eligible_symbol_counts_by_date,
+        maximum_position_count,
         trade_symbol_lookup,
         closing_price_series_by_symbol,
         withdraw_amount,


### PR DESCRIPTION
## Summary
- Implement slot-based position sizing using a maximum position count and optional weight cap
- Thread new sizing logic through strategy evaluation and portfolio metrics
- Add tests for fixed slot sizing and budget skips

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68af7052ba70832bbb6c86840e52c0a4