### PR TITLE
Add SEC sector pipeline with Fama-French mapping

### DIFF
--- a/src/stock_indicator/sector_pipeline/__init__.py
+++ b/src/stock_indicator/sector_pipeline/__init__.py
@@ -1,0 +1,3 @@
+"""Sector classification pipeline built on SEC and Fama-French data."""
+
+# TODO: review

--- a/src/stock_indicator/sector_pipeline/config.py
+++ b/src/stock_indicator/sector_pipeline/config.py
@@ -1,0 +1,21 @@
+"""Configuration settings for the sector classification pipeline."""
+
+# TODO: review
+
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+SEC_COMPANY_TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
+SEC_SUBMISSIONS_URL_TEMPLATE = "https://data.sec.gov/submissions/CIK{cik_padded}.json"
+SEC_USER_AGENT = "Your Name your_email@example.com"
+
+CACHE_DIRECTORY = REPOSITORY_ROOT / "cache"
+SUBMISSIONS_DIRECTORY = CACHE_DIRECTORY / "submissions"
+LAST_RUN_CONFIG_PATH = CACHE_DIRECTORY / "last_run.json"
+
+DATA_DIRECTORY = REPOSITORY_ROOT / "data"
+DEFAULT_OUTPUT_PARQUET_PATH = DATA_DIRECTORY / "symbols_with_sector.parquet"
+DEFAULT_OUTPUT_CSV_PATH = DATA_DIRECTORY / "symbols_with_sector.csv"
+
+NORMALIZE_DOT_TO_DASH = True

--- a/src/stock_indicator/sector_pipeline/ff_mapping.py
+++ b/src/stock_indicator/sector_pipeline/ff_mapping.py
@@ -1,0 +1,78 @@
+"""Functions for loading and applying Fama-French industry mappings."""
+
+# TODO: review
+
+import io
+import logging
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def load_fama_french_mapping(source: str | Path) -> pd.DataFrame:
+    """Load the Fama-French mapping table from ``source``.
+
+    ``source`` may be a URL or a path to a CSV file.
+    """
+    source_str = str(source)
+    if source_str.startswith("http://") or source_str.startswith("https://"):
+        try:
+            logger.info("Downloading Fama-French mapping from %s", source_str)
+            response = requests.get(source_str, timeout=30)
+            response.raise_for_status()
+            mapping_data_frame = pd.read_csv(io.BytesIO(response.content))
+        except requests.RequestException as error:
+            logger.error("Failed to download mapping from %s: %s", source_str, error)
+            raise
+    else:
+        mapping_path = Path(source_str)
+        mapping_data_frame = pd.read_csv(mapping_path)
+    mapping_data_frame.columns = [
+        column.strip().lower() for column in mapping_data_frame.columns
+    ]
+    if "sic" in mapping_data_frame.columns and "sic_start" not in mapping_data_frame.columns:
+        mapping_data_frame["sic_start"] = mapping_data_frame["sic"].astype(int)
+        mapping_data_frame["sic_end"] = mapping_data_frame["sic"].astype(int)
+    for column_name in ("ff12", "ff48", "ff49"):
+        if column_name not in mapping_data_frame.columns:
+            mapping_data_frame[column_name] = -1
+    if "label" not in mapping_data_frame.columns:
+        mapping_data_frame["label"] = ""
+    mapping_data_frame["sic_start"] = mapping_data_frame["sic_start"].astype(int)
+    mapping_data_frame["sic_end"] = mapping_data_frame["sic_end"].astype(int)
+    return mapping_data_frame[["sic_start", "sic_end", "ff12", "ff48", "ff49", "label"]]
+
+
+def build_classification_lookup(mapping_data_frame: pd.DataFrame) -> pd.DataFrame:
+    """Expand SIC ranges into an explicit lookup table."""
+    classification_rows: list[dict[str, Any]] = []
+    for mapping_row in mapping_data_frame.itertuples(index=False):
+        start_code = int(mapping_row.sic_start)
+        end_code = int(mapping_row.sic_end)
+        for classification_code in range(start_code, end_code + 1):
+            classification_rows.append(
+                {
+                    "sic": classification_code,
+                    "ff12": int(mapping_row.ff12),
+                    "ff48": int(mapping_row.ff48),
+                    "ff49": int(mapping_row.ff49),
+                    "ff_label": mapping_row.label,
+                }
+            )
+    return pd.DataFrame(classification_rows)
+
+
+def attach_fama_french_groups(
+    data_frame: pd.DataFrame, classification_lookup: pd.DataFrame
+) -> pd.DataFrame:
+    """Merge Fama-French classifications into ``data_frame`` using ``sic`` codes."""
+    merged_data_frame = data_frame.merge(classification_lookup, on="sic", how="left")
+    merged_data_frame["ff12"] = merged_data_frame["ff12"].fillna(-1).astype(int)
+    merged_data_frame["ff48"] = merged_data_frame["ff48"].fillna(-1).astype(int)
+    merged_data_frame["ff49"] = merged_data_frame["ff49"].fillna(-1).astype(int)
+    merged_data_frame["ff_label"] = merged_data_frame["ff_label"].fillna("UNKNOWN")
+    return merged_data_frame

--- a/src/stock_indicator/sector_pipeline/pipeline.py
+++ b/src/stock_indicator/sector_pipeline/pipeline.py
@@ -1,0 +1,114 @@
+"""End-to-end pipeline for tagging symbols with SIC and Fama-French groups."""
+
+# TODO: review
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import requests
+
+from .config import (
+    CACHE_DIRECTORY,
+    SUBMISSIONS_DIRECTORY,
+    LAST_RUN_CONFIG_PATH,
+    DEFAULT_OUTPUT_PARQUET_PATH,
+    DEFAULT_OUTPUT_CSV_PATH,
+)
+from .utils import ensure_directory_exists, save_json_file, load_json_file
+from .sec_api import map_tickers_to_central_index_and_classification
+from .ff_mapping import (
+    load_fama_french_mapping,
+    build_classification_lookup,
+    attach_fama_french_groups,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def load_universe(source: str | Path) -> pd.DataFrame:
+    """Load a universe of ticker symbols from ``source``.
+
+    ``source`` may be a CSV file with a ``ticker`` column or a newline-separated list
+    of symbols provided as a file or URL.
+    """
+    source_str = str(source)
+    if source_str.endswith(".csv"):
+        data_frame = pd.read_csv(source_str)
+        if "ticker" not in data_frame.columns:
+            raise ValueError("CSV input must contain a 'ticker' column")
+        return data_frame[["ticker"]].dropna().drop_duplicates()
+    if source_str.startswith("http://") or source_str.startswith("https://"):
+        try:
+            logger.info("Downloading ticker universe from %s", source_str)
+            response = requests.get(source_str, timeout=30)
+            response.raise_for_status()
+            text = response.text
+        except requests.RequestException as error:
+            logger.error("Failed to download ticker universe from %s: %s", source_str, error)
+            raise
+    else:
+        with Path(source_str).open("r", encoding="utf-8") as file_pointer:
+            text = file_pointer.read()
+    tickers = [symbol.strip().upper() for symbol in text.splitlines() if symbol.strip()]
+    return pd.DataFrame({"ticker": tickers})
+
+
+def build_sector_classification_dataset(
+    symbols_source: str | Path,
+    mapping_source: str | Path,
+    output_parquet_path: Path = DEFAULT_OUTPUT_PARQUET_PATH,
+    output_csv_path: Optional[Path] = DEFAULT_OUTPUT_CSV_PATH,
+) -> pd.DataFrame:
+    """Generate a data set of symbols tagged with CIK, SIC, and Fama-French codes."""
+    ensure_directory_exists(CACHE_DIRECTORY)
+    ensure_directory_exists(SUBMISSIONS_DIRECTORY)
+    universe_data_frame = load_universe(symbols_source)
+    ticker_mapping_data_frame = map_tickers_to_central_index_and_classification(
+        universe_data_frame
+    )
+    mapping_data_frame = load_fama_french_mapping(mapping_source)
+    lookup_data_frame = build_classification_lookup(mapping_data_frame)
+    classified_data_frame = attach_fama_french_groups(
+        ticker_mapping_data_frame, lookup_data_frame
+    )
+    classified_data_frame["sic_desc"] = ""
+    ensure_directory_exists(output_parquet_path.parent)
+    classified_data_frame.to_parquet(output_parquet_path, index=False)
+    if output_csv_path is not None:
+        ensure_directory_exists(output_csv_path.parent)
+        classified_data_frame.to_csv(output_csv_path, index=False)
+    save_json_file(
+        {
+            "symbols_source": str(symbols_source),
+            "mapping_source": str(mapping_source),
+            "output": str(output_parquet_path),
+        },
+        LAST_RUN_CONFIG_PATH,
+    )
+    return classified_data_frame
+
+
+def update_latest_dataset() -> pd.DataFrame:
+    """Rebuild the classification data using the most recent configuration."""
+    configuration = load_json_file(LAST_RUN_CONFIG_PATH)
+    return build_sector_classification_dataset(
+        configuration["symbols_source"],
+        configuration["mapping_source"],
+        Path(configuration.get("output", DEFAULT_OUTPUT_PARQUET_PATH)),
+    )
+
+
+def generate_coverage_report(data_frame: pd.DataFrame) -> str:
+    """Return coverage information for ``data_frame`` as a formatted string."""
+    total_count = len(data_frame)
+    with_cik = data_frame["cik"].notna().sum()
+    with_sic = data_frame["sic"].notna().sum()
+    with_fama_french = (data_frame["ff48"] != -1).sum()
+    return (
+        f"Total: {total_count}\n"
+        f"CIK: {with_cik} ({with_cik / total_count:.1%})\n"
+        f"SIC: {with_sic} ({with_sic / total_count:.1%})\n"
+        f"FF tag: {with_fama_french} ({with_fama_french / total_count:.1%})"
+    )

--- a/src/stock_indicator/sector_pipeline/sec_api.py
+++ b/src/stock_indicator/sector_pipeline/sec_api.py
@@ -1,0 +1,139 @@
+"""Interfaces with the SEC for company and submission data."""
+
+# TODO: review
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+import requests
+
+from .config import (
+    SEC_COMPANY_TICKERS_URL,
+    SEC_SUBMISSIONS_URL_TEMPLATE,
+    SEC_USER_AGENT,
+    SUBMISSIONS_DIRECTORY,
+)
+from .utils import (
+    ensure_directory_exists,
+    save_json_file,
+    load_json_file,
+    sleep_politely,
+    normalize_ticker_symbol,
+)
+
+logger = logging.getLogger(__name__)
+
+HEADERS = {"User-Agent": SEC_USER_AGENT}
+
+
+def _format_central_index_key(central_index_key: int) -> str:
+    """Return the central index key padded to ten digits."""
+    return f"{int(central_index_key):010d}"
+
+
+def _request_json(url: str) -> Dict[str, Any]:
+    """Fetch JSON data from ``url`` with basic retries."""
+    for attempt in range(3):
+        try:
+            logger.info("Requesting %s", url)
+            response = requests.get(url, headers=HEADERS, timeout=30)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as error:
+            logger.error(
+                "Request to %s failed on attempt %s: %s",
+                url,
+                attempt + 1,
+                error,
+            )
+            if attempt == 2:
+                raise
+            time.sleep(2 ** attempt)
+    return {}
+
+
+def fetch_company_ticker_table() -> pd.DataFrame:
+    """Retrieve a table mapping ticker symbols to central index keys."""
+    data = _request_json(SEC_COMPANY_TICKERS_URL)
+    rows = []
+    for company_info in data.values():
+        ticker_normalized = normalize_ticker_symbol(company_info["ticker"])
+        rows.append(
+            {
+                "ticker": ticker_normalized,
+                "cik": int(company_info["cik_str"]),
+                "title": company_info.get("title"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _submissions_cache_path(central_index_key: int) -> Path:
+    """Return the cache path for a submission JSON file."""
+    file_name = f"CIK{_format_central_index_key(central_index_key)}.json"
+    return SUBMISSIONS_DIRECTORY / file_name
+
+
+def fetch_submissions_json(central_index_key: int, use_cache: bool = True) -> Dict[str, Any] | None:
+    """Fetch SEC submission data for ``central_index_key`` using a local cache."""
+    ensure_directory_exists(SUBMISSIONS_DIRECTORY)
+    cache_path = _submissions_cache_path(central_index_key)
+    if use_cache and cache_path.exists():
+        try:
+            return load_json_file(cache_path)
+        except (OSError, json.JSONDecodeError) as error:
+            logger.warning("Failed to load cache %s: %s", cache_path, error)
+    url = SEC_SUBMISSIONS_URL_TEMPLATE.format(
+        cik_padded=_format_central_index_key(central_index_key)
+    )
+    data = _request_json(url)
+    save_json_file(data, cache_path)
+    sleep_politely()
+    return data
+
+
+def extract_standard_industrial_classification(submission_data: Dict[str, Any]) -> int | None:
+    """Extract the standard industrial classification code from a submission payload."""
+    try:
+        sic_value = submission_data.get("sic")
+        return int(sic_value) if sic_value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def map_tickers_to_central_index_and_classification(
+    universe_data_frame: pd.DataFrame,
+) -> pd.DataFrame:
+    """Attach central index keys and SIC codes to ticker symbols."""
+    sec_mapping_data_frame = fetch_company_ticker_table()
+    universe_copy = universe_data_frame.copy()
+    universe_copy["ticker_normalized"] = universe_copy["ticker"].map(
+        normalize_ticker_symbol
+    )
+    sec_mapping_data_frame["ticker_normalized"] = sec_mapping_data_frame["ticker"]
+    merged_data_frame = universe_copy.merge(
+        sec_mapping_data_frame[["ticker_normalized", "cik"]],
+        on="ticker_normalized",
+        how="left",
+    ).drop(columns=["ticker_normalized"])
+    central_index_key_values = sorted(
+        value for value in merged_data_frame["cik"].dropna().unique()
+    )
+    classification_rows = []
+    for central_index_key_value in central_index_key_values:
+        submissions_json = fetch_submissions_json(int(central_index_key_value), use_cache=True)
+        classification_code = None
+        if submissions_json:
+            classification_code = extract_standard_industrial_classification(submissions_json)
+        classification_rows.append(
+            {
+                "cik": int(central_index_key_value),
+                "sic": classification_code,
+            }
+        )
+    cik_sic_data_frame = pd.DataFrame(classification_rows)
+    return merged_data_frame.merge(cik_sic_data_frame, on="cik", how="left")

--- a/src/stock_indicator/sector_pipeline/utils.py
+++ b/src/stock_indicator/sector_pipeline/utils.py
@@ -1,0 +1,43 @@
+"""Utility helpers for file handling, rate limiting, and ticker normalization."""
+
+# TODO: review
+
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_directory_exists(directory_path: Path) -> None:
+    """Create ``directory_path`` if it does not already exist."""
+    directory_path.mkdir(parents=True, exist_ok=True)
+
+
+def save_json_file(data: Any, file_path: Path) -> None:
+    """Write ``data`` as JSON to ``file_path``."""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with file_path.open("w", encoding="utf-8") as file_pointer:
+        json.dump(data, file_pointer, ensure_ascii=False, indent=2)
+
+
+def load_json_file(file_path: Path) -> Any:
+    """Load and return JSON content from ``file_path``."""
+    with file_path.open("r", encoding="utf-8") as file_pointer:
+        return json.load(file_pointer)
+
+
+def sleep_politely(seconds: float = 0.12) -> None:
+    """Pause execution for ``seconds`` to respect remote API rate limits."""
+    time.sleep(seconds)
+
+
+def normalize_ticker_symbol(symbol: str, convert_dash_to_dot: bool = True) -> str:
+    """Return an upper-case ticker symbol, converting dashes to dots if requested."""
+    cleaned_symbol = (symbol or "").strip().upper()
+    if convert_dash_to_dot:
+        return re.sub(r"(?<=\w)-(?!$)", ".", cleaned_symbol)
+    return cleaned_symbol

--- a/tests/test_sector_pipeline.py
+++ b/tests/test_sector_pipeline.py
@@ -1,0 +1,45 @@
+import pandas as pd
+
+from stock_indicator.sector_pipeline.utils import normalize_ticker_symbol
+from stock_indicator.sector_pipeline.ff_mapping import (
+    build_classification_lookup,
+    attach_fama_french_groups,
+)
+
+
+def test_normalize_ticker_symbol_converts_dash_to_dot():
+    assert normalize_ticker_symbol("brk-b") == "BRK.B"
+
+
+def test_build_classification_lookup_expands_ranges():
+    mapping_data_frame = pd.DataFrame(
+        {
+            "sic_start": [1000],
+            "sic_end": [1002],
+            "ff12": [1],
+            "ff48": [2],
+            "ff49": [3],
+            "label": ["Test"],
+        }
+    )
+    lookup_data_frame = build_classification_lookup(mapping_data_frame)
+    assert len(lookup_data_frame) == 3
+    assert (
+        lookup_data_frame.loc[lookup_data_frame["sic"] == 1001, "ff48"].iloc[0] == 2
+    )
+
+
+def test_attach_fama_french_groups_merges_lookup():
+    data_frame = pd.DataFrame({"sic": [1001]})
+    lookup_data_frame = pd.DataFrame(
+        {
+            "sic": [1001],
+            "ff12": [1],
+            "ff48": [2],
+            "ff49": [3],
+            "ff_label": ["Label"],
+        }
+    )
+    merged_data_frame = attach_fama_french_groups(data_frame, lookup_data_frame)
+    assert merged_data_frame["ff48"].iloc[0] == 2
+    assert merged_data_frame["ff_label"].iloc[0] == "Label"


### PR DESCRIPTION
## Summary
- create `sector_pipeline` package for SEC and Fama-French sector classification
- add utilities for file IO and ticker normalization
- implement pipeline to download SEC data, map SIC codes, and merge Fama-French groups
- include unit tests for ticker normalization and Fama-French mapping logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68afd4fa89c8832bb58aba886cbddcf9