### PR TITLE
feat: add trade detail flag to start_simulate

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -38,6 +38,11 @@ averages. The tests
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 exercise this combined syntax.
 
+A numeric stop loss and a trailing `True` or `False` flag may follow the
+strategy names. The stop loss specifies the fractional decline that triggers an
+exit on the next day's open, and the boolean flag controls whether individual
+trade details are printed.
+
 The simulation report lists the maximum drawdown alongside other metrics. This
 percentage indicates the greatest decline from any previous portfolio peak.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ selects the six highest-volume symbols from the remainder. The tests
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 demonstrate this combined syntax.
 
+An optional stop loss value and a trailing `True` or `False` flag may be added
+after the strategy names. The numeric stop loss sets the fractional decline
+that triggers an exit on the next day's open, and the boolean flag controls
+whether individual trade details are printed.
+
 Strategies may also limit the simple moving average slope. These identifiers follow the `ema_sma_signal_with_slope_n_k` pattern where `n` and `k` are the lower and upper slope bounds. The bounds accept negative or positive floating-point numbers. For example:
 
 ```bash


### PR DESCRIPTION
## Summary
- allow `start_simulate` to accept a `SHOW_DETAILS` flag after `STOP_LOSS`
- print trade details only when the flag is true
- document new flag and add regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68afc3092e20832b92238523f8c33d14