### PR TITLE
Add sector pipeline and manage shell tests

### DIFF
--- a/tests/sector_pipeline/conftest.py
+++ b/tests/sector_pipeline/conftest.py
@@ -1,0 +1,52 @@
+"""Fixtures for sector pipeline tests."""
+
+# TODO: review
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def company_ticker_payload() -> dict:
+    """Return a minimal SEC company ticker table payload."""
+    return {
+        "0": {"cik_str": "1", "ticker": "AAA", "title": "Alpha Company"},
+        "1": {"cik_str": "2", "ticker": "BBB", "title": "Beta Company"},
+    }
+
+
+@pytest.fixture
+def submissions_payloads() -> dict:
+    """Return submission payloads keyed by central index key."""
+    return {1: {"sic": 1000}, 2: {"sic": 2000}}
+
+
+@pytest.fixture
+def universe_file(tmp_path: Path) -> Path:
+    """Create a text file listing a small ticker universe."""
+    file_path = tmp_path / "universe.txt"
+    file_path.write_text("AAA\nBBB\n", encoding="utf-8")
+    return file_path
+
+
+@pytest.fixture
+def ff_mapping_file(tmp_path: Path) -> Path:
+    """Create a CSV file representing a SIC to Fama-French mapping."""
+    csv_content = (
+        "sic_start,sic_end,ff12,ff48,ff49,label\n"
+        "1000,1999,1,10,100,Alpha\n"
+        "2000,2999,2,20,200,Beta\n"
+    )
+    file_path = tmp_path / "mapping.csv"
+    file_path.write_text(csv_content, encoding="utf-8")
+    return file_path
+
+
+@pytest.fixture
+def ff_mapping_csv_text() -> str:
+    """Return CSV text used for mocking HTTP responses."""
+    return (
+        "sic_start,sic_end,ff12,ff48,ff49,label\n"
+        "1000,1999,1,10,100,Alpha\n"
+    )

--- a/tests/sector_pipeline/test_ff_mapping.py
+++ b/tests/sector_pipeline/test_ff_mapping.py
@@ -1,0 +1,24 @@
+"""Tests for Fama-French mapping utilities with mocked downloads."""
+
+# TODO: review
+
+
+def test_load_fama_french_mapping_downloads_csv(monkeypatch, ff_mapping_csv_text) -> None:
+    """The loader should fetch and parse a mapping CSV from a URL."""
+    import stock_indicator.sector_pipeline.ff_mapping as ff_mapping_module
+
+    class FakeResponse:
+        def __init__(self, text: str) -> None:
+            self.content = text.encode('utf-8')
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def fake_get(url: str, timeout: int = 30) -> 'FakeResponse':
+        return FakeResponse(ff_mapping_csv_text)
+
+    monkeypatch.setattr(ff_mapping_module.requests, 'get', fake_get)
+
+    data_frame = ff_mapping_module.load_fama_french_mapping('http://example.com/mapping.csv')
+    assert list(data_frame.columns) == ['sic_start', 'sic_end', 'ff12', 'ff48', 'ff49', 'label']
+    assert data_frame.iloc[0]['ff48'] == 10

--- a/tests/sector_pipeline/test_pipeline.py
+++ b/tests/sector_pipeline/test_pipeline.py
@@ -1,0 +1,41 @@
+"""Tests for building and updating the sector classification dataset."""
+
+# TODO: review
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_build_and_update_dataset(monkeypatch, tmp_path, company_ticker_payload, submissions_payloads, universe_file, ff_mapping_file) -> None:
+    """The pipeline should build and refresh classification data."""
+    import stock_indicator.sector_pipeline.sec_api as sec_api_module
+    import stock_indicator.sector_pipeline.pipeline as pipeline_module
+
+    def fake_fetch_company_ticker_table() -> pd.DataFrame:
+        return pd.DataFrame([
+            {"ticker": "AAA", "cik": 1, "title": "Alpha Company"},
+            {"ticker": "BBB", "cik": 2, "title": "Beta Company"},
+        ])
+
+    def fake_fetch_submissions_json(central_index_key: int, use_cache: bool = True) -> dict:
+        return submissions_payloads[central_index_key]
+
+    monkeypatch.setattr(sec_api_module, 'fetch_company_ticker_table', fake_fetch_company_ticker_table)
+    monkeypatch.setattr(sec_api_module, 'fetch_submissions_json', fake_fetch_submissions_json)
+    monkeypatch.setattr(sec_api_module, 'SUBMISSIONS_DIRECTORY', tmp_path / 'submissions')
+
+    monkeypatch.setattr(pipeline_module, 'LAST_RUN_CONFIG_PATH', tmp_path / 'last_run.json')
+    monkeypatch.setattr(pipeline_module, 'DEFAULT_OUTPUT_PARQUET_PATH', tmp_path / 'output.parquet')
+    monkeypatch.setattr(pipeline_module, 'DEFAULT_OUTPUT_CSV_PATH', tmp_path / 'output.csv')
+    monkeypatch.setattr(pipeline_module, 'SUBMISSIONS_DIRECTORY', tmp_path / 'submissions')
+    monkeypatch.setattr(pd.DataFrame, 'to_parquet', lambda self, *a, **k: None)
+
+    data_frame = pipeline_module.build_sector_classification_dataset(
+        universe_file, ff_mapping_file, tmp_path / 'output.parquet', tmp_path / 'output.csv'
+    )
+    assert set(data_frame['ff48']) == {10, 20}
+    assert (tmp_path / 'last_run.json').exists()
+
+    updated_data_frame = pipeline_module.update_latest_dataset()
+    assert len(updated_data_frame) == 2

--- a/tests/sector_pipeline/test_sec_api.py
+++ b/tests/sector_pipeline/test_sec_api.py
@@ -1,0 +1,58 @@
+"""Tests for SEC API utilities with mocked HTTP requests."""
+
+# TODO: review
+
+
+def test_fetch_company_ticker_table(monkeypatch, company_ticker_payload) -> None:
+    """The function should parse the company ticker table payload."""
+    import stock_indicator.sector_pipeline.sec_api as sec_api_module
+
+    class FakeResponse:
+        def __init__(self, data: dict) -> None:
+            self.data = data
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return self.data
+
+    def fake_get(url: str, headers: dict | None = None, timeout: int = 30) -> 'FakeResponse':
+        return FakeResponse(company_ticker_payload)
+
+    monkeypatch.setattr(sec_api_module.requests, 'get', fake_get)
+
+    data_frame = sec_api_module.fetch_company_ticker_table()
+    assert set(data_frame['ticker']) == {'AAA', 'BBB'}
+    assert data_frame.loc[data_frame['ticker'] == 'AAA', 'cik'].iloc[0] == 1
+
+
+def test_fetch_submissions_json_uses_cache(monkeypatch, tmp_path, submissions_payloads) -> None:
+    """Submissions should be cached after the first HTTP request."""
+    import stock_indicator.sector_pipeline.sec_api as sec_api_module
+
+    call_counter = {'count': 0}
+
+    class FakeResponse:
+        def __init__(self, payload: dict) -> None:
+            self.payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return self.payload
+
+    def fake_get(url: str, headers: dict | None = None, timeout: int = 30) -> 'FakeResponse':
+        call_counter['count'] += 1
+        return FakeResponse(submissions_payloads[1])
+
+    monkeypatch.setattr(sec_api_module.requests, 'get', fake_get)
+    monkeypatch.setattr(sec_api_module, 'SUBMISSIONS_DIRECTORY', tmp_path)
+
+    first_result = sec_api_module.fetch_submissions_json(1, use_cache=True)
+    second_result = sec_api_module.fetch_submissions_json(1, use_cache=True)
+
+    assert first_result == submissions_payloads[1]
+    assert second_result == submissions_payloads[1]
+    assert call_counter['count'] == 1


### PR DESCRIPTION
## Summary
- Add fixtures for sample SEC responses and SIC to Fama-French mapping
- Test SEC API and Fama-French mapping functions with mocked HTTP calls
- Exercise pipeline build/update and manage shell's sector update command

## Testing
- `pytest tests/sector_pipeline tests/test_manage.py::test_update_sector_data_without_arguments tests/test_manage.py::test_update_sector_data_with_arguments -q`

------
https://chatgpt.com/codex/tasks/task_b_68afea154c38832baa8ae5af0dc331ab