### PR TITLE
Use SEC company tickers as sole universe

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Calling `update_latest_dataset` later reloads that configuration and rebuilds
 the output while reusing the cached submissions, so only new symbols require
 additional downloads. The resulting table is written to
 `data/symbols_with_sector.parquet` and can also be exported as a CSV file.
+The ticker universe is always derived from the SEC `company_tickers.json`
+dataset and cannot be overridden with a custom list.
 
 ## Contribution Guidelines
 1. Fork the repository and create a new branch for each feature or bug fix.

--- a/_from_chatGPT/sec_sic_ff_pipeline_v2/README.md
+++ b/_from_chatGPT/sec_sic_ff_pipeline_v2/README.md
@@ -8,5 +8,5 @@ Quick start
 1) pip install -r requirements.txt
 2) Set SEC_USER_AGENT in src/sec_pipeline/config.py
 3) Build:
-   python main.py build      --symbols-url https://raw.githubusercontent.com/rreichel3/US-Stock-Symbols/main/all/all_tickers.txt      --ff-map-url https://raw.githubusercontent.com/Wenzhi-Ding/FamaFrenchIndustry/main/ff_48ind.csv      --out data/symbols_with_sector.parquet
+   python main.py build --ff-map-url https://raw.githubusercontent.com/Wenzhi-Ding/FamaFrenchIndustry/main/ff_48ind.csv --out data/symbols_with_sector.parquet
 4) Outputs at data/symbols_with_sector.parquet and .csv

--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -38,7 +38,10 @@ def determine_start_date(data_directory: Path) -> str:
             continue
         if date_frame.empty:
             continue
-        first_date = date_frame.iloc[0, 0].date()
+        first_value = date_frame.iloc[0, 0]
+        if not hasattr(first_value, "date"):
+            continue
+        first_date = first_value.date()
         if earliest_date is None or first_date < earliest_date:
             earliest_date = first_date
     if earliest_date is None:

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -112,7 +112,7 @@ class StockShell(cmd.Cmd):
         )
 
     def do_update_sector_data(self, argument_line: str) -> None:  # noqa: D401
-        """update_sector_data [--symbols-url=URL --ff-map-url=URL OUTPUT_PATH]
+        """update_sector_data [--ff-map-url=URL OUTPUT_PATH]
         Refresh the local sector classification data set."""
         argument_parts: List[str] = argument_line.split()
         if not argument_parts:
@@ -123,33 +123,24 @@ class StockShell(cmd.Cmd):
             coverage_report = pipeline.generate_coverage_report(data_frame)
             self.stdout.write(f"{coverage_report}\n")
             return
-        symbols_url: str | None = None
         mapping_url: str | None = None
         output_path_string: str | None = None
         for token in argument_parts:
-            if token.startswith("--symbols-url="):
-                symbols_url = token.split("=", 1)[1]
-            elif token.startswith("--ff-map-url="):
+            if token.startswith("--ff-map-url="):
                 mapping_url = token.split("=", 1)[1]
             else:
                 output_path_string = token
-        if (
-            symbols_url is None
-            or mapping_url is None
-            or output_path_string is None
-        ):
+        if mapping_url is None or output_path_string is None:
             self.stdout.write(
-                "usage: update_sector_data --symbols-url=URL --ff-map-url=URL OUTPUT_PATH\n",
+                "usage: update_sector_data --ff-map-url=URL OUTPUT_PATH\n",
             )
             return
         output_path = Path(output_path_string)
         LOGGER.info(
-            "Building sector classification data using %s and %s",
-            symbols_url,
+            "Building sector classification data using %s",
             mapping_url,
         )
         data_frame = pipeline.build_sector_classification_dataset(
-            symbols_url,
             mapping_url,
             output_path,
         )
@@ -159,11 +150,11 @@ class StockShell(cmd.Cmd):
     def help_update_sector_data(self) -> None:
         """Display help for the update_sector_data command."""
         self.stdout.write(
-            "update_sector_data --symbols-url=URL --ff-map-url=URL OUTPUT_PATH\n"
+            "update_sector_data --ff-map-url=URL OUTPUT_PATH\n"
             "Refresh sector classification data from SEC and Fama-French sources.\n"
+            "The ticker universe is sourced from the SEC company tickers dataset.\n"
             "Without parameters, rebuilds data using the last saved configuration.\n"
             "Parameters:\n"
-            "  --symbols-url: URL or file path listing ticker symbols.\n"
             "  --ff-map-url: URL or file path to SIC to Fama-French mapping.\n"
             "  OUTPUT_PATH: Destination path for the Parquet output file.\n"
         )

--- a/tests/sector_pipeline/test_pipeline.py
+++ b/tests/sector_pipeline/test_pipeline.py
@@ -7,24 +7,25 @@ from pathlib import Path
 import pandas as pd
 
 
-def test_build_and_update_dataset(monkeypatch, tmp_path, company_ticker_payload, submissions_payloads, universe_file, ff_mapping_file) -> None:
+def test_build_and_update_dataset(monkeypatch, tmp_path, submissions_payloads, ff_mapping_file) -> None:
     """The pipeline should build and refresh classification data."""
     import stock_indicator.sector_pipeline.sec_api as sec_api_module
     import stock_indicator.sector_pipeline.pipeline as pipeline_module
 
-    def fake_fetch_company_ticker_table() -> pd.DataFrame:
+    def fake_load_company_tickers() -> pd.DataFrame:
         return pd.DataFrame([
-            {"ticker": "AAA", "cik": 1, "title": "Alpha Company"},
-            {"ticker": "BBB", "cik": 2, "title": "Beta Company"},
+            {"ticker": "AAA", "cik": 1},
+            {"ticker": "BBB", "cik": 2},
         ])
 
     def fake_fetch_submissions_json(central_index_key: int, use_cache: bool = True) -> dict:
         return submissions_payloads[central_index_key]
 
-    monkeypatch.setattr(sec_api_module, 'fetch_company_ticker_table', fake_fetch_company_ticker_table)
+    monkeypatch.setattr(sec_api_module, 'load_company_tickers', fake_load_company_tickers)
     monkeypatch.setattr(sec_api_module, 'fetch_submissions_json', fake_fetch_submissions_json)
     monkeypatch.setattr(sec_api_module, 'SUBMISSIONS_DIRECTORY', tmp_path / 'submissions')
 
+    monkeypatch.setattr(pipeline_module, 'load_company_tickers', fake_load_company_tickers)
     monkeypatch.setattr(pipeline_module, 'LAST_RUN_CONFIG_PATH', tmp_path / 'last_run.json')
     monkeypatch.setattr(pipeline_module, 'DEFAULT_OUTPUT_PARQUET_PATH', tmp_path / 'output.parquet')
     monkeypatch.setattr(pipeline_module, 'DEFAULT_OUTPUT_CSV_PATH', tmp_path / 'output.csv')
@@ -32,7 +33,7 @@ def test_build_and_update_dataset(monkeypatch, tmp_path, company_ticker_payload,
     monkeypatch.setattr(pd.DataFrame, 'to_parquet', lambda self, *a, **k: None)
 
     data_frame = pipeline_module.build_sector_classification_dataset(
-        universe_file, ff_mapping_file, tmp_path / 'output.parquet', tmp_path / 'output.csv'
+        ff_mapping_file, tmp_path / 'output.parquet', tmp_path / 'output.csv'
     )
     assert set(data_frame['ff48']) == {10, 20}
     assert (tmp_path / 'last_run.json').exists()

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -1360,9 +1360,8 @@ def test_update_sector_data_with_arguments(monkeypatch: pytest.MonkeyPatch, tmp_
     call_arguments: dict[str, object] = {}
 
     def fake_build_sector_classification_dataset(
-        symbols_url: str, mapping_url: str, output_path: Path
+        mapping_url: str, output_path: Path
     ) -> pandas.DataFrame:
-        call_arguments["symbols"] = symbols_url
         call_arguments["mapping"] = mapping_url
         call_arguments["output"] = output_path
         return pandas.DataFrame({"ticker": ["AAA"], "ff48": [1]})
@@ -1382,11 +1381,10 @@ def test_update_sector_data_with_arguments(monkeypatch: pytest.MonkeyPatch, tmp_
     output_buffer = io.StringIO()
     shell = manage_module.StockShell(stdout=output_buffer)
     shell.onecmd(
-        f"update_sector_data --symbols-url=http://sym --ff-map-url=http://map {tmp_path/'out.parquet'}"
+        f"update_sector_data --ff-map-url=http://map {tmp_path/'out.parquet'}"
     )
 
     assert call_arguments == {
-        "symbols": "http://sym",
         "mapping": "http://map",
         "output": tmp_path / "out.parquet",
     }


### PR DESCRIPTION
## Summary
- add `load_company_tickers` helper and teach mapping to use existing CIKs
- derive sector pipeline universe from SEC dataset, dropping user-provided symbol lists
- simplify CLI: `update_sector_data` now only needs `--ff-map-url` and output path

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b019c2440c832b93bb8428b96f65bc