### PR TITLE
Document group ratio and Top-N rule for find_signal

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -54,9 +54,9 @@ selling strategies instead.
 
 Each execution of the daily job records entry and exit signals in a log file in
 the project's `logs` directory using the `<YYYY-MM-DD>.log` naming convention.
-The `find_signal` command recalculates the signals for a specific date rather
-than reading the log files. The management shell can compute signals for a
-specific day with:
+The `find_signal` command recalculates the signals for a specific date rather than reading the log files.
+Signal calculation uses the same group dynamic ratio and Top-N rule as `start_simulate`.
+The management shell can compute signals for a specific day with:
 
 ```
 find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ python -m stock_indicator.manage
 * `update_all_data_from_yf START END` performs the download for every cached symbol.
 * `find_signal DATE DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID)`
   recalculates the entry and exit signals for `DATE` using explicit buy/sell
-  names or a strategy set id (see Strategy Sets below).
+  names or a strategy set id (see Strategy Sets below). Signal calculation uses
+  the same group dynamic ratio and Top-N rule as `start_simulate`.
 
 For example:
 
@@ -80,7 +81,7 @@ For example:
 
 Developers can also call `daily_job.find_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)` to compute
 the same data from Python code. This function recalculates signals rather than
-reading them from log files.
+reading them from log files. Signal calculation uses the same group dynamic ratio and Top-N rule as `start_simulate`.
 
 The shell can also simulate trading strategies. The `dollar_volume` filter
 accepts a minimum threshold in millions, a percentage of total market volume,
@@ -140,7 +141,7 @@ Shorthand forms using a strategy id (omit explicit buy/sell tokens):
 - N symbols
   - `start_simulate_n_symbol symbols=QQQ,SPY [starting_cash=...] [withdraw=...] [start=YYYY-MM-DD] [STOP_LOSS] [SHOW_DETAILS] strategy=ID`
 - Find signal
-  - `find_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID [group=1,2,...]`
+  - `find_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID [group=1,2,...]` — signal calculation uses the same group dynamic ratio and Top-N rule as `start_simulate`.
 
 Notes:
 - When `strategy=ID` is present, do not include explicit `BUY`/`SELL` tokens.

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1258,6 +1258,7 @@ class StockShell(cmd.Cmd):
         self.stdout.write(
             "find_signal DATE DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
             "Display entry and exit signals for DATE using the provided strategies or a strategy id from data/strategy_sets.csv.\n"
+            "Signal calculation uses the same group dynamic ratio and Top-N rule as start_simulate.\n"
         )
 
 


### PR DESCRIPTION
## Summary
- clarify in `Docs/Usage.md` that `find_signal` applies the same group dynamic ratio and Top-N rule as `start_simulate`
- mention the group ratio and Top-N rule in `README.md` and CLI `help_find_signal`
- restore accidentally modified data files

## Testing
- `pytest` *(fails: assert mismatch; ImportError; ProxyError)*

------
https://chatgpt.com/codex/tasks/task_b_68b3e2410b88832b8a57d5cab3270a4a