### PR TITLE
Allow stop-loss strategy-id form in find_signal

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1168,15 +1168,18 @@ class StockShell(cmd.Cmd):
 
     # TODO: review
     def do_find_signal(self, argument_line: str) -> None:  # noqa: D401
-        """find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS [group=...] [strategy=ID]
+        """find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
+        [group=...] or find_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID
+        [group=...]
+
         Display the entry and exit signals generated for DATE."""
         usage_message = (
             "usage: find_signal DATE DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
         )
         argument_parts: List[str] = argument_line.split()
-        if len(argument_parts) not in (5, 6, 7):
+        if len(argument_parts) < 4:
             self.stdout.write(usage_message)
-            return
+            return  # TODO: review
         # Optional group token may appear in any position after DATE; normalize
         allowed_group_identifiers: set[int] | None = None
         tokens: List[str] = []


### PR DESCRIPTION
## Summary
- Relax argument parsing in `find_signal` to accept `STOP_LOSS strategy=ID` syntax
- Add unit test exercising `strategy=ID` option and update existing tests

## Testing
- `pytest tests/test_manage.py::test_find_signal_prints_recalculated_signals tests/test_manage.py::test_find_signal_invalid_argument tests/test_manage.py::test_find_signal_with_strategy_id -q`
- `pytest -q` *(fails: Unsupported strategy: fake_strategy; too many values to unpack; ProxyError; etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68b3e6b552cc832b8d9ab0491044920d