### PR TITLE
Clarify find_signal strategy usage

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -56,17 +56,19 @@ Each execution of the daily job records entry and exit signals in a log file in
 the project's `logs` directory using the `<YYYY-MM-DD>.log` naming convention.
 The `find_signal` command recalculates the signals for a specific date rather than reading the log files.
 Signal calculation uses the same group dynamic ratio and Top-N rule as `start_simulate`.
-The management shell can compute signals for a specific day with:
+The management shell can compute signals for a specific day with either form:
 
 ```
 find_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
+find_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID
 ```
 
-The command prints the entry signal list on the first line and the exit signal
-list on the second line. For example:
+Accepted forms are `BUY SELL STOP_LOSS` or `STOP_LOSS strategy=ID`. The command
+prints the entry signal list on the first line and the exit signal list on the
+second line. For example:
 
 ```
-find_signal 2024-01-10 dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
+find_signal 2024-01-10 dollar_volume>1 1.0 strategy=default
 ['AAA', 'BBB']
 ['CCC', 'DDD']
 ```

--- a/README.md
+++ b/README.md
@@ -66,15 +66,17 @@ python -m stock_indicator.manage
 * `update_data_from_yf SYMBOL START END` saves historical data for the given symbol to
   `data/<SYMBOL>.csv`.
 * `update_all_data_from_yf START END` performs the download for every cached symbol.
-* `find_signal DATE DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID)`
-  recalculates the entry and exit signals for `DATE` using explicit buy/sell
-  names or a strategy set id (see Strategy Sets below). Signal calculation uses
-  the same group dynamic ratio and Top-N rule as `start_simulate`.
+* `find_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID`
+  recalculates the entry and exit signals for `DATE`. Accepted forms are
+  `BUY SELL STOP_LOSS` or `STOP_LOSS strategy=ID`. The first form supplies
+  explicit buy and sell strategy names, while the second references a strategy
+  set identifier (see Strategy Sets below). Signal calculation uses the same
+  group dynamic ratio and Top-N rule as `start_simulate`.
 
 For example:
 
 ```bash
-(stock-indicator) find_signal 2024-01-10 dollar_volume>1 strategy=default 1.0
+(stock-indicator) find_signal 2024-01-10 dollar_volume>1 1.0 strategy=default
 ['AAA', 'BBB']
 ['CCC', 'DDD']
 ```


### PR DESCRIPTION
## Summary
- Document two accepted trailing argument forms for `find_signal`
- Show example using `strategy=ID` with stop loss placed before strategy option

## Testing
- `pytest` *(fails: Unsupported strategy, TypeError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_b_68b3e8e18d14832b82328773e9270cfe