### PR TITLE
fix: use explicit strategy names in daily job

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -8,7 +8,8 @@ SOURCE_DIRECTORY="${SRC:-$REPOSITORY_ROOT/src}"
 VIRTUAL_ENVIRONMENT_DIRECTORY="${VENV:-$REPOSITORY_ROOT/venv}"
 
 # Your daily_job argument line:
-ARG_LINE='dollar_volume>2.14%,Top3 strategy=s1 0.1'
+# TODO: review
+ARG_LINE='dollar_volume>2.14%,Top3 ema_sma_cross ema_sma_cross 0.1'
 
 # Set up logging directory
 LOG_DIRECTORY="$REPOSITORY_ROOT/cron_logs"


### PR DESCRIPTION
## Summary
- use explicit buy/sell strategy names in `run_daily_job.sh`
- mark argument line for review

## Testing
- `pytest` (fails: requests.exceptions.ProxyError and unsupported strategy errors)

------
https://chatgpt.com/codex/tasks/task_b_68b3f2bd907c832ba11c4951dbc5f7c3