### PR TITLE
Clarify find_signal output

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1252,8 +1252,8 @@ class StockShell(cmd.Cmd):
         )
         entry_signal_list: List[str] = signal_data.get("entry_signals", [])
         exit_signal_list: List[str] = signal_data.get("exit_signals", [])
-        self.stdout.write(f"{entry_signal_list}\n")
-        self.stdout.write(f"{exit_signal_list}\n")
+        self.stdout.write(f"entry signals: {entry_signal_list}\n")
+        self.stdout.write(f"exit signals: {exit_signal_list}\n")
 
     # TODO: review
     def help_find_signal(self) -> None:

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -132,7 +132,10 @@ def test_find_signal_prints_recalculated_signals(monkeypatch: pytest.MonkeyPatch
         "sell": "ema_sma_cross",
         "stop": 1.0,
     }
-    assert output_buffer.getvalue().splitlines() == ["['AAA']", "['BBB']"]
+    assert output_buffer.getvalue().splitlines() == [
+        "entry signals: ['AAA']",
+        "exit signals: ['BBB']",
+    ]
 
 
 # TODO: review


### PR DESCRIPTION
## Summary
- Label entry and exit signals in `find_signal` command output
- Adjust tests to match updated output

## Testing
- `pytest` *(fails: ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68b430c493e0832bbd9ee44ff08d07c5