### PR TITLE
Use 60-bar lookback for chip metrics

### DIFF
--- a/src/stock_indicator/chip_filter.py
+++ b/src/stock_indicator/chip_filter.py
@@ -6,7 +6,7 @@ import pandas
 
 def calculate_chip_concentration_metrics(
     ohlcv: pandas.DataFrame,
-    lookback_window_size: int = 120,
+    lookback_window_size: int = 60,
     bin_count: int = 50,
     near_price_band_ratio: float = 0.03,
 ) -> dict[str, float | int | None]:
@@ -16,7 +16,7 @@ def calculate_chip_concentration_metrics(
     ----------
     ohlcv : pandas.DataFrame
         Data frame with ``high``, ``low``, ``close`` and ``volume`` columns.
-    lookback_window_size : int, default 120
+    lookback_window_size : int, default 60
         Number of rows to include in the calculation window.
     bin_count : int, default 50
         Number of price bins used for the histogram.

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -1654,8 +1654,9 @@ def evaluate_combined_strategy(
             else:
                 group_entry_ratio = float(entry_dollar_volume) / group_entry_total
             chip_metrics = calculate_chip_concentration_metrics(
-                price_data_frame.loc[: completed_trade.entry_date]
-            )
+                price_data_frame.loc[: completed_trade.entry_date],
+                lookback_window_size=60,
+            )  # TODO: review
             entry_detail = TradeDetail(
                 date=completed_trade.entry_date,
                 symbol=symbol_name,


### PR DESCRIPTION
## Summary
- compute chip concentration metrics using a 60-bar lookback window
- apply explicit 60-bar lookback when deriving trade details

## Testing
- `pytest -q --maxfail=1` *(fails: ValueError: Unsupported strategy: fake_strategy)*

------
https://chatgpt.com/codex/tasks/task_b_68b495ba9170832b8a48305bf39a4a79