### PR TITLE
Ensure start_simulate overwrites results file

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -649,10 +649,10 @@ class StockShell(cmd.Cmd):
                         "percentage_change": detail.percentage_change,
                     }
                 )
-        output_directory = Path("logs") / "simulate_result"
+        output_directory = Path("logs")
         output_directory.mkdir(parents=True, exist_ok=True)
-        timestamp_string = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_file = output_directory / f"simulation_{timestamp_string}.csv"
+        output_file = output_directory / "simulate_result.csv"
+        output_file.unlink(missing_ok=True)
         pandas.DataFrame(
             trade_records,
             columns=[

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -1477,10 +1477,9 @@ def test_start_simulate_creates_csv(
         "start_simulate start=2024-01-01 dollar_volume>1 ema_sma_cross ema_sma_cross"
     )
 
-    result_directory = tmp_path / "logs" / "simulate_result"
-    csv_files = list(result_directory.glob("simulation_*.csv"))
-    assert len(csv_files) == 1
-    data_frame = pandas.read_csv(csv_files[0])
+    result_file = tmp_path / "logs" / "simulate_result.csv"
+    assert result_file.exists()
+    data_frame = pandas.read_csv(result_file)
     assert list(data_frame.columns) == [
         "year",
         "entry_date",


### PR DESCRIPTION
## Summary
- Write simulation results to `logs/simulate_result.csv` and remove any old file before writing
- Adjust integration test to expect fixed `simulate_result.csv` path

## Testing
- `pytest -q` *(fails: numerous missing strategy functions and network access issues)*

------
https://chatgpt.com/codex/tasks/task_b_68b498978808832ba3f686d14d548f92