### PR TITLE
Remove long-term SMA requirement from EMA/SMA slope strategy

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -872,11 +872,10 @@ def attach_ema_sma_cross_with_slope_signals(
     sma_window_factor: float | None = None,
 ) -> None:
     """Attach EMA/SMA cross signals filtered by simple moving average slope.
-
-    Entry signals require the prior-day EMA cross, the previous closing price to
-    be above the 150-day simple moving average, the simple moving average slope
-    to fall within ``slope_range``, and chip concentration metrics that meet the
-    ``loose`` thresholds (``near_price_volume_ratio`` ≤ ``0.12`` and
+    
+    Entry signals require the prior-day EMA cross, the simple moving average
+    slope to fall within ``slope_range``, and chip concentration metrics that
+    meet the ``loose`` thresholds (``near_price_volume_ratio`` ≤ ``0.12`` and
     ``above_price_volume_ratio`` ≤ ``0.10``). Unless a slope range is provided
     in the strategy name, this function uses the default range ``(-0.3, 2.14)``.
     The magnitude of the slope depends on ``window_size``; larger windows
@@ -912,7 +911,7 @@ def attach_ema_sma_cross_with_slope_signals(
     attach_ema_sma_cross_signals(
         price_data_frame,
         window_size,
-        require_close_above_long_term_sma=True,
+        require_close_above_long_term_sma=False,
         sma_window_factor=sma_window_factor,
     )
     price_data_frame["sma_slope"] = (

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1552,10 +1552,10 @@ def test_attach_ftd_ema_sma_cross_signals_requires_recent_ftd(
     ]
 
 
-def test_attach_ema_sma_cross_with_slope_requires_close_above_long_term_sma_and_slope_in_range(
+def test_attach_ema_sma_cross_with_slope_filters_by_slope_and_chip_concentration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The EMA/SMA cross entry requires long-term SMA, slope, and chip filters."""
+    """The EMA/SMA cross entry applies slope and chip concentration filters."""
     # TODO: review
 
     import stock_indicator.strategy as strategy_module
@@ -1576,6 +1576,7 @@ def test_attach_ema_sma_cross_with_slope_requires_close_above_long_term_sma_and_
         data_frame: pandas.DataFrame,
         window_size: int = 50,
         require_close_above_long_term_sma: bool = True,
+        sma_window_factor: float | None = None,
     ) -> None:
         nonlocal recorded_require_close_above_long_term_sma
         recorded_require_close_above_long_term_sma = require_close_above_long_term_sma
@@ -1620,7 +1621,7 @@ def test_attach_ema_sma_cross_with_slope_requires_close_above_long_term_sma_and_
 
     strategy_module.attach_ema_sma_cross_with_slope_signals(price_data_frame)
 
-    assert recorded_require_close_above_long_term_sma is True
+    assert recorded_require_close_above_long_term_sma is False
     assert list(price_data_frame["ema_sma_cross_with_slope_entry_signal"]) == [
         False,
         False,


### PR DESCRIPTION
## Summary
- Drop 150-day SMA filter from `attach_ema_sma_cross_with_slope_signals`
- Update tests to reflect new entry logic without long-term SMA requirement

## Testing
- `pytest tests/test_strategy.py::test_attach_ema_sma_cross_with_slope_filters_by_slope_and_chip_concentration -q`
- `pytest tests/test_strategy.py::test_attach_ema_sma_cross_with_slope_signals_raises_value_error_for_invalid_slope_range -q`
- `pytest tests/test_strategy.py::test_attach_ema_sma_cross_with_slope_and_volume_requires_higher_ema_volume -q` *(fails: module 'stock_indicator.strategy' has no attribute 'attach_ema_sma_cross_with_slope_and_volume_signals')*


------
https://chatgpt.com/codex/tasks/task_b_68b548fa80cc832b9a9818bbcc149ab9