### PR TITLE
Add EMA/SMA cross testing strategy with chip concentration filters

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -87,6 +87,7 @@ The `start_simulate` command accepts the following strategies:
 * `ftd_ema_sma_cross`
 * `ema_sma_cross_with_slope` *(use `ema_sma_cross_with_slope_N` to set a custom EMA/SMA window size; `N` defaults to 40. Append `_LOWER_UPPER` to constrain the simple moving average slope to a range.)*
 * `ema_sma_cross_with_slope_and_volume`
+* `ema_sma_cross_testing`
 * `ema_sma_double_cross`
 * `kalman_filtering` *(sell only)*
 
@@ -107,6 +108,12 @@ The window size and slope range can be combined by placing the integer before th
 ```
 start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-0.1_1.2 ema_sma_cross_with_slope_40_-0.1_1.2
 ```
+
+The testing variant `ema_sma_cross_testing` accepts the same optional window
+size and slope range suffixes. In addition to the EMA/SMA cross and slope
+filters, it recalculates chip concentration metrics and requires both the
+near-price and above-price volume ratios to remain below 0.12 and 0.10 by
+default.
 
 The tests `tests/test_manage.py::test_start_simulate_accepts_slope_range_strategy_names` and `tests/test_strategy.py::test_evaluate_combined_strategy_passes_slope_range` confirm this behavior. The management test shows the command accepts strategy names with slope bounds, and the strategy test verifies that the evaluation routine passes the bounds to the strategy implementation.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ You can combine slope bounds with a custom EMA/SMA window size by placing the in
 (stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-0.1_1.2 ema_sma_cross_with_slope_40_-0.1_1.2
 ```
 
+For experimentation, the `ema_sma_cross_testing` strategy offers the same
+optional window size and slope range suffixes. It omits the long-term simple
+moving average requirement and additionally filters signals using chip
+concentration metrics, enforcing default thresholds of 0.12 for the near-price
+volume ratio and 0.10 for the above-price volume ratio.
+
 When omitted, the window size defaults to 40 days.
 
 ### Strategy Sets


### PR DESCRIPTION
## Summary
- implement `attach_ema_sma_cross_testing_signals` combining EMA/SMA cross, slope filtering, and chip concentration thresholds
- expose new `ema_sma_cross_testing` identifier and document usage
- add unit tests for new strategy and strategy map entry

## Testing
- `pytest tests/test_strategy.py::test_attach_ema_sma_cross_testing_filters_by_slope_and_chip tests/test_strategy.py::test_attach_ema_sma_cross_testing_signals_raises_value_error_for_invalid_slope_range tests/test_strategy.py::test_supported_strategies_includes_ema_sma_cross_testing -q`

------
https://chatgpt.com/codex/tasks/task_b_68b558cb4334832b99c8bd9e811f6d1e