### PR TITLE
Normalize SMA slopes using angles

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -85,7 +85,7 @@ The `start_simulate` command accepts the following strategies:
 * `20_50_sma_cross`
 * `ema_sma_cross_and_rsi`
 * `ftd_ema_sma_cross`
-* `ema_sma_cross_with_slope` *(use `ema_sma_cross_with_slope_N` to set a custom EMA/SMA window size; `N` defaults to 40. Append `_LOWER_UPPER` to constrain the simple moving average slope to a range.)*
+* `ema_sma_cross_with_slope` *(use `ema_sma_cross_with_slope_N` to set a custom EMA/SMA window size; `N` defaults to 40. Append `_LOWER_UPPER` to constrain the simple moving average angle to a range in degrees.)*
 * `ema_sma_cross_with_slope_and_volume`
 * `ema_sma_cross_testing`
 * `ema_sma_double_cross`
@@ -97,16 +97,16 @@ To change the EMA and SMA window size, append `_N` to `ema_sma_cross_with_slope`
 start_simulate dollar_volume>1 ema_sma_cross_with_slope_40 ema_sma_cross_with_slope_40
 ```
 
-To limit the slope of the simple moving average, add two numeric bounds after the optional window size. Both bounds may be negative or positive floating-point numbers. These strategies follow the generic `ema_sma_signal_with_slope_n_k` pattern and use the format `ema_sma_cross_with_slope[_N]_LOWER_UPPER`:
+To limit the angle of the simple moving average, add two numeric bounds after the optional window size. Both bounds may be negative or positive floating-point numbers representing degrees. These strategies follow the generic `ema_sma_signal_with_slope_n_k` pattern and use the format `ema_sma_cross_with_slope[_N]_LOWER_UPPER`:
 
 ```
-start_simulate dollar_volume>1 ema_sma_cross_with_slope_-0.1_1.2 ema_sma_cross_with_slope_-0.1_1.2
+start_simulate dollar_volume>1 ema_sma_cross_with_slope_-5.7_50.2 ema_sma_cross_with_slope_-5.7_50.2
 ```
 
 The window size and slope range can be combined by placing the integer before the slope bounds:
 
 ```
-start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-0.1_1.2 ema_sma_cross_with_slope_40_-0.1_1.2
+start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-5.7_50.2 ema_sma_cross_with_slope_40_-5.7_50.2
 ```
 
 The testing variant `ema_sma_cross_testing` accepts the same optional window

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ whether individual trade details are printed.
 Strategies may also limit the simple moving average slope. These identifiers follow the `ema_sma_signal_with_slope_n_k` pattern where `n` and `k` are the lower and upper slope bounds. The bounds accept negative or positive floating-point numbers. For example:
 
 ```bash
-(stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_with_slope_-0.1_1.2 ema_sma_cross_with_slope_-0.1_1.2
+(stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_with_slope_-5.7_50.2 ema_sma_cross_with_slope_-5.7_50.2
 ```
 
 You can combine slope bounds with a custom EMA/SMA window size by placing the integer before the bounds:
 
 ```bash
-(stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-0.1_1.2 ema_sma_cross_with_slope_40_-0.1_1.2
+(stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-5.7_50.2 ema_sma_cross_with_slope_40_-5.7_50.2
 ```
 
 For experimentation, the `ema_sma_cross_testing` strategy offers the same

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import math
 from math import ceil
 from pathlib import Path
 from statistics import mean, stdev
 from typing import Callable, Dict, List
 
 import re
+import numpy
 import pandas
 
 from .indicators import ema, kalman_filter, sma
@@ -25,6 +27,17 @@ from .simulator import (
     simulate_trades,
 )
 from .symbols import SP500_SYMBOL
+
+
+DEFAULT_SMA_ANGLE_RANGE: tuple[float, float] = (
+    math.degrees(math.atan(-0.3)),
+    math.degrees(math.atan(2.14)),
+)
+
+DEFAULT_SHIFTED_EMA_ANGLE_RANGE: tuple[float, float] = (
+    math.degrees(math.atan(-1.0)),
+    math.degrees(math.atan(1.0)),
+)
 
 
 def _split_strategy_choices(strategy_name: str) -> list[str]:
@@ -569,7 +582,7 @@ def compute_signals_for_date(
         full_name: str,
         base_name: str,
         window_size: int | None,
-        slope_range: tuple[float, float] | None,
+        angle_range: tuple[float, float] | None,
         table: Dict[str, Callable[[pandas.DataFrame], None]],
         frame: pandas.DataFrame,
     ) -> None:
@@ -581,8 +594,8 @@ def compute_signals_for_date(
         else:
             if window_size is not None:
                 kwargs["window_size"] = window_size
-            if slope_range is not None:
-                kwargs["slope_range"] = slope_range
+            if angle_range is not None:
+                kwargs["angle_range"] = angle_range
             sma_factor_value = _extract_sma_factor(full_name)
             if sma_factor_value is not None and base_name in {"ema_sma_cross", "ema_sma_cross_with_slope"}:
                 kwargs["sma_window_factor"] = sma_factor_value
@@ -602,13 +615,13 @@ def compute_signals_for_date(
         buy_signal_columns: list[str] = []
         for buy_name in buy_choice_names:
             try:
-                base_name, window_size, slope_range = parse_strategy_name(buy_name)
+                base_name, window_size, angle_range = parse_strategy_name(buy_name)
             except Exception:  # noqa: BLE001
                 continue
             if base_name not in BUY_STRATEGIES:
                 continue
             _apply_strategy(
-                buy_name, base_name, window_size, slope_range, BUY_STRATEGIES, price_data_frame
+                buy_name, base_name, window_size, angle_range, BUY_STRATEGIES, price_data_frame
             )
             column_name = f"{buy_name}_entry_signal"
             if column_name in price_data_frame.columns:
@@ -617,13 +630,13 @@ def compute_signals_for_date(
         sell_signal_columns: list[str] = []
         for sell_name in sell_choice_names:
             try:
-                base_name, window_size, slope_range = parse_strategy_name(sell_name)
+                base_name, window_size, angle_range = parse_strategy_name(sell_name)
             except Exception:  # noqa: BLE001
                 continue
             if base_name not in SELL_STRATEGIES:
                 continue
             _apply_strategy(
-                sell_name, base_name, window_size, slope_range, SELL_STRATEGIES, price_data_frame
+                sell_name, base_name, window_size, angle_range, SELL_STRATEGIES, price_data_frame
             )
             column_name = f"{sell_name}_exit_signal"
             if column_name in price_data_frame.columns:
@@ -865,18 +878,19 @@ def attach_20_50_sma_cross_signals(
 def attach_ema_sma_cross_with_slope_signals(
     price_data_frame: pandas.DataFrame,
     window_size: int = 40,
-    slope_range: tuple[float, float] = (-0.3, 2.14),
+    angle_range: tuple[float, float] = DEFAULT_SMA_ANGLE_RANGE,
     sma_window_factor: float | None = None,
+    bounds_as_tangent: bool = False,
 ) -> None:
-    """Attach EMA/SMA cross signals filtered by simple moving average slope.
+    """Attach EMA/SMA cross signals filtered by simple moving average angle.
 
     Entry signals require the prior-day EMA cross, the simple moving average
-    slope to fall within ``slope_range``, and the closing price to remain above
-    the long-term simple moving average. Unless a slope range is provided in the
-    strategy name, this function uses the default range ``(-0.3, 2.14)``. The
-    magnitude of the slope depends on ``window_size``; larger windows produce
-    smaller slope values, so adjust ``slope_range`` accordingly when overriding
-    the default.
+    angle to fall within ``angle_range``, and the closing price to remain above
+    the long-term simple moving average. Unless an angle range is provided in
+    the strategy name, this function uses the default range derived from the
+    tangents ``(-0.3, 2.14)`` converted to degrees. The normalized slope scales
+    with ``window_size``; larger windows produce smaller relative changes, so
+    adjust ``angle_range`` accordingly when overriding the default.
 
     Parameters
     ----------
@@ -884,8 +898,10 @@ def attach_ema_sma_cross_with_slope_signals(
         DataFrame containing ``open`` and ``close`` price columns.
     window_size:
         Number of periods for EMA calculations.
-    slope_range:
-        Inclusive range ``(lower_bound, upper_bound)`` for the SMA slope.
+    angle_range:
+        Inclusive range ``(lower_bound, upper_bound)`` for the SMA angle in
+        degrees. When ``bounds_as_tangent`` is ``True``, interpret the bounds as
+        tangents and convert them to degrees.
     sma_window_factor:
         Optional multiplier applied to ``window_size`` to determine the SMA
         window as ``ceil(window_size * factor)``. When ``None``, uses
@@ -894,14 +910,17 @@ def attach_ema_sma_cross_with_slope_signals(
     Raises
     ------
     ValueError
-        If ``slope_range`` has a lower bound greater than its upper bound.
+        If ``angle_range`` has a lower bound greater than its upper bound.
     """
     # TODO: review
 
-    slope_lower_bound, slope_upper_bound = slope_range
-    if slope_lower_bound > slope_upper_bound:
+    angle_lower_bound, angle_upper_bound = angle_range
+    if bounds_as_tangent:
+        angle_lower_bound = math.degrees(math.atan(angle_lower_bound))
+        angle_upper_bound = math.degrees(math.atan(angle_upper_bound))
+    if angle_lower_bound > angle_upper_bound:
         raise ValueError(
-            "Invalid slope_range: lower bound cannot exceed upper bound"
+            "Invalid angle_range: lower bound cannot exceed upper bound"
         )
 
     attach_ema_sma_cross_signals(
@@ -910,13 +929,14 @@ def attach_ema_sma_cross_with_slope_signals(
         require_close_above_long_term_sma=True,
         sma_window_factor=sma_window_factor,
     )
-    price_data_frame["sma_slope"] = (
+    relative_change = (
         price_data_frame["sma_value"] - price_data_frame["sma_previous"]
-    )
+    ) / price_data_frame["sma_previous"]
+    price_data_frame["sma_angle"] = numpy.degrees(numpy.arctan(relative_change))
     price_data_frame["ema_sma_cross_with_slope_entry_signal"] = (
         price_data_frame["ema_sma_cross_entry_signal"]
-        & (price_data_frame["sma_slope"] >= slope_lower_bound)
-        & (price_data_frame["sma_slope"] <= slope_upper_bound)
+        & (price_data_frame["sma_angle"] >= angle_lower_bound)
+        & (price_data_frame["sma_angle"] <= angle_upper_bound)
     )
     price_data_frame["ema_sma_cross_with_slope_exit_signal"] = price_data_frame[
         "ema_sma_cross_exit_signal"
@@ -926,12 +946,13 @@ def attach_ema_sma_cross_with_slope_signals(
 def attach_ema_sma_cross_testing_signals(
     price_data_frame: pandas.DataFrame,
     window_size: int = 40,
-    slope_range: tuple[float, float] = (-0.3, 2.14),
+    angle_range: tuple[float, float] = DEFAULT_SMA_ANGLE_RANGE,
     near_pct: float = 0.12,
     above_pct: float = 0.10,
     sma_window_factor: float | None = None,
+    bounds_as_tangent: bool = False,
 ) -> None:
-    """Attach EMA/SMA cross testing signals with slope and chip filters.
+    """Attach EMA/SMA cross testing signals with angle and chip filters.
 
     Entry signals mirror :func:`attach_ema_sma_cross_with_slope_signals` but do
     not require the closing price to remain above the long-term simple moving
@@ -946,8 +967,10 @@ def attach_ema_sma_cross_testing_signals(
         ``volume`` columns.
     window_size:
         Number of periods for EMA calculations.
-    slope_range:
-        Inclusive range ``(lower_bound, upper_bound)`` for the SMA slope.
+    angle_range:
+        Inclusive range ``(lower_bound, upper_bound)`` for the SMA angle in
+        degrees. When ``bounds_as_tangent`` is ``True``, interpret the bounds as
+        tangents and convert them to degrees.
     near_pct:
         Maximum allowed fraction of volume near the current price.
     above_pct:
@@ -960,14 +983,17 @@ def attach_ema_sma_cross_testing_signals(
     Raises
     ------
     ValueError
-        If ``slope_range`` has a lower bound greater than its upper bound.
+        If ``angle_range`` has a lower bound greater than its upper bound.
     """
     # TODO: review
 
-    slope_lower_bound, slope_upper_bound = slope_range
-    if slope_lower_bound > slope_upper_bound:
+    angle_lower_bound, angle_upper_bound = angle_range
+    if bounds_as_tangent:
+        angle_lower_bound = math.degrees(math.atan(angle_lower_bound))
+        angle_upper_bound = math.degrees(math.atan(angle_upper_bound))
+    if angle_lower_bound > angle_upper_bound:
         raise ValueError(
-            "Invalid slope_range: lower bound cannot exceed upper bound"
+            "Invalid angle_range: lower bound cannot exceed upper bound"
         )
 
     attach_ema_sma_cross_signals(
@@ -976,9 +1002,10 @@ def attach_ema_sma_cross_testing_signals(
         require_close_above_long_term_sma=False,
         sma_window_factor=sma_window_factor,
     )
-    price_data_frame["sma_slope"] = (
+    relative_change = (
         price_data_frame["sma_value"] - price_data_frame["sma_previous"]
-    )
+    ) / price_data_frame["sma_previous"]
+    price_data_frame["sma_angle"] = numpy.degrees(numpy.arctan(relative_change))
 
     near_ratios: List[float | None] = []
     above_ratios: List[float | None] = []
@@ -1000,8 +1027,8 @@ def attach_ema_sma_cross_testing_signals(
     above_ok = price_data_frame["above_price_volume_ratio"].le(above_pct)
     price_data_frame["ema_sma_cross_testing_entry_signal"] = (
         price_data_frame["ema_sma_cross_entry_signal"]
-        & (price_data_frame["sma_slope"] >= slope_lower_bound)
-        & (price_data_frame["sma_slope"] <= slope_upper_bound)
+        & (price_data_frame["sma_angle"] >= angle_lower_bound)
+        & (price_data_frame["sma_angle"] <= angle_upper_bound)
         & near_ok.fillna(False)
         & above_ok.fillna(False)
     )
@@ -1013,9 +1040,10 @@ def attach_ema_sma_cross_testing_signals(
 def attach_ema_shift_cross_with_slope_signals(
     price_data_frame: pandas.DataFrame,
     window_size: int = 35,
-    slope_range: tuple[float, float] = (-1.0, 1.0),
+    angle_range: tuple[float, float] = DEFAULT_SHIFTED_EMA_ANGLE_RANGE,
+    bounds_as_tangent: bool = False,
 ) -> None:
-    """Attach EMA/EMA(shifted) cross signals filtered by EMA slope.
+    """Attach EMA/EMA(shifted) cross signals filtered by EMA angle.
 
     This strategy mirrors :func:`attach_ema_sma_cross_with_slope_signals` but
     replaces the simple moving average with an exponential moving average
@@ -1023,7 +1051,7 @@ def attach_ema_shift_cross_with_slope_signals(
 
     Entry conditions:
     - Previous day's EMA crosses above the shifted EMA
-    - The shifted EMA slope falls within ``slope_range``
+    - The shifted EMA angle falls within ``angle_range``
 
     Exit condition:
     - Previous day's EMA crosses below the shifted EMA
@@ -1035,22 +1063,28 @@ def attach_ema_shift_cross_with_slope_signals(
     window_size:
         Number of periods for both EMAs. Defaults to ``35`` when not specified
         in the strategy name.
-    slope_range:
-        Inclusive range ``(lower_bound, upper_bound)`` for the shifted EMA
-        slope (difference to previous value). Defaults to ``(-1.0, 1.0)``.
+    angle_range:
+        Inclusive range ``(lower_bound, upper_bound)`` for the shifted EMA angle
+        in degrees. When ``bounds_as_tangent`` is ``True``, interpret bounds as
+        tangents and convert them to degrees.
+    bounds_as_tangent:
+        When ``True``, interpret ``angle_range`` as tangent bounds rather than
+        degrees.
 
     Raises
     ------
     ValueError
-        If ``slope_range`` has a lower bound greater than its upper bound.
+        If ``angle_range`` has a lower bound greater than its upper bound.
     """
-    slope_lower_bound, slope_upper_bound = slope_range
-    if slope_lower_bound > slope_upper_bound:
+    angle_lower_bound, angle_upper_bound = angle_range
+    if bounds_as_tangent:
+        angle_lower_bound = math.degrees(math.atan(angle_lower_bound))
+        angle_upper_bound = math.degrees(math.atan(angle_upper_bound))
+    if angle_lower_bound > angle_upper_bound:
         raise ValueError(
-            "Invalid slope_range: lower bound cannot exceed upper bound"
+            "Invalid angle_range: lower bound cannot exceed upper bound",
         )
 
-    # Core moving averages
     _close_r3 = price_data_frame["close"].round(3)
     price_data_frame["ema_value"] = ema(_close_r3, window_size)
     price_data_frame["shifted_close"] = price_data_frame["close"].round(3).shift(3)
@@ -1058,13 +1092,9 @@ def attach_ema_shift_cross_with_slope_signals(
         price_data_frame["shifted_close"], window_size
     )
 
-    # Previous-day values for stable cross detection
     price_data_frame["ema_previous"] = price_data_frame["ema_value"].shift(1)
-    price_data_frame["shifted_ema_previous"] = price_data_frame[
-        "shifted_ema_value"
-    ].shift(1)
+    price_data_frame["shifted_ema_previous"] = price_data_frame["shifted_ema_value"].shift(1)
 
-    # Cross detection
     crosses_up = (
         (price_data_frame["ema_previous"] <= price_data_frame["shifted_ema_previous"])
         & (price_data_frame["ema_value"] > price_data_frame["shifted_ema_value"])
@@ -1074,20 +1104,20 @@ def attach_ema_shift_cross_with_slope_signals(
         & (price_data_frame["ema_value"] < price_data_frame["shifted_ema_value"])
     )
 
-    # Slope of shifted EMA
-    price_data_frame["shifted_ema_slope"] = (
-        price_data_frame["shifted_ema_value"]
-        - price_data_frame["shifted_ema_previous"]
+    relative_change = (
+        price_data_frame["shifted_ema_value"] - price_data_frame["shifted_ema_previous"]
+    ) / price_data_frame["shifted_ema_previous"]
+    price_data_frame["shifted_ema_angle"] = numpy.degrees(
+        numpy.arctan(relative_change)
     )
 
-    # Build signals using prior-day confirmation
     base_entry = crosses_up.shift(1, fill_value=False)
     base_exit = crosses_down.shift(1, fill_value=False)
 
     price_data_frame["ema_shift_cross_with_slope_entry_signal"] = (
         base_entry
-        & (price_data_frame["shifted_ema_slope"] >= slope_lower_bound)
-        & (price_data_frame["shifted_ema_slope"] <= slope_upper_bound)
+        & (price_data_frame["shifted_ema_angle"] >= angle_lower_bound)
+        & (price_data_frame["shifted_ema_angle"] <= angle_upper_bound)
     )
     price_data_frame["ema_shift_cross_with_slope_exit_signal"] = base_exit
 
@@ -1122,29 +1152,29 @@ SUPPORTED_STRATEGIES: Dict[str, Callable[[pandas.DataFrame], None]] = {
 def parse_strategy_name(
     strategy_name: str,
 ) -> tuple[str, int | None, tuple[float, float] | None]:
-    """Split ``strategy_name`` into base name, window size, and slope range.
+    """Split ``strategy_name`` into base name, window size, and angle range.
 
     Strategy identifiers may include a numeric window size suffix or a pair of
-    floating-point numbers representing a slope range. These components are
+    floating-point numbers representing an angle range. These components are
     separated from the base name by underscores. For example,
     ``"ema_sma_cross_with_slope_40_-0.5_0.5"`` is interpreted as the base
-    strategy ``"ema_sma_cross_with_slope"`` with a window size of ``40`` and a
-    slope range from ``-0.5`` to ``0.5``.
+    strategy ``"ema_sma_cross_with_slope"`` with a window size of ``40`` and an
+    angle range from ``-0.5`` to ``0.5``.
 
     Any optional trailing ``_sma{factor}`` suffix (e.g., ``_sma1.2``) is ignored
-    for base-name/window/slope parsing and should be obtained via
+    for base-name/window/angle parsing and should be obtained via
     :func:`_extract_sma_factor` if needed.
 
     Parameters
     ----------
     strategy_name:
         The full strategy name possibly containing a numeric suffix and an
-        optional slope range.
+        optional angle range.
 
     Returns
     -------
     tuple[str, int | None, tuple[float, float] | None]
-        The base strategy name, the integer window size, and the slope range as
+        The base strategy name, the integer window size, and the angle range as
         a ``(lower, upper)`` tuple. When a component is not present, its value
         is ``None``.
 
@@ -1191,7 +1221,7 @@ def parse_strategy_name(
                 )
             return base_name, window_size, None
         raise ValueError(
-            "Malformed strategy name: expected two numeric segments for slope range "
+            "Malformed strategy name: expected two numeric segments for angle range "
             f"but found {segment_count} in '{strategy_name}'"
         )
 
@@ -1206,7 +1236,7 @@ def parse_strategy_name(
         window_value = numeric_segments[0]
         if not window_value.isdigit():
             raise ValueError(
-                "Malformed strategy name: expected two numeric segments for slope range "
+                "Malformed strategy name: expected two numeric segments for angle range "
                 f"but found {segment_count} in '{strategy_name}'"
             )
         window_size = int(window_value)
@@ -1571,7 +1601,7 @@ def evaluate_combined_strategy(
         buy_bases_for_cooldown: set[str] = set()
         for buy_name in _split_strategy_choices(buy_strategy_name):
             try:
-                base_name, window_size, slope_range = parse_strategy_name(buy_name)
+                base_name, window_size, angle_range = parse_strategy_name(buy_name)
             except Exception:
                 continue
             if base_name not in BUY_STRATEGIES:
@@ -1586,8 +1616,8 @@ def evaluate_combined_strategy(
             else:
                 if window_size is not None:
                     kwargs["window_size"] = window_size
-                if slope_range is not None:
-                    kwargs["slope_range"] = slope_range
+                if angle_range is not None:
+                    kwargs["angle_range"] = angle_range
                 # Optional SMA window factor support for EMA/SMA strategies
                 sma_factor_value = _extract_sma_factor(buy_name)
                 if sma_factor_value is not None and base_name in {"ema_sma_cross", "ema_sma_cross_with_slope"}:
@@ -1615,7 +1645,7 @@ def evaluate_combined_strategy(
         sell_signal_columns: list[str] = []
         for sell_name in _split_strategy_choices(sell_strategy_name):
             try:
-                base_name, window_size, slope_range = parse_strategy_name(sell_name)
+                base_name, window_size, angle_range = parse_strategy_name(sell_name)
             except Exception:
                 continue
             if base_name not in SELL_STRATEGIES:
@@ -1629,8 +1659,8 @@ def evaluate_combined_strategy(
             else:
                 if window_size is not None:
                     kwargs["window_size"] = window_size
-                if slope_range is not None:
-                    kwargs["slope_range"] = slope_range
+                if angle_range is not None:
+                    kwargs["angle_range"] = angle_range
                 sma_factor_value = _extract_sma_factor(sell_name)
                 if sma_factor_value is not None and base_name in {"ema_sma_cross", "ema_sma_cross_with_slope"}:
                     kwargs["sma_window_factor"] = sma_factor_value

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -230,17 +230,18 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     from stock_indicator.strategy import StrategyMetrics, TradeDetail
 
     def fake_evaluate(
-        data_directory: Path,
-        buy_strategy_name: str,
-        sell_strategy_name: str,
-        minimum_average_dollar_volume: float | None,
-        top_dollar_volume_rank: int | None = None,
-        minimum_average_dollar_volume_ratio: float | None = None,
-        starting_cash: float = 3000.0,
-        withdraw_amount: float = 0.0,
-        stop_loss_percentage: float = 1.0,
-        start_date: pandas.Timestamp | None = None,
-    ) -> StrategyMetrics:
+            data_directory: Path,
+            buy_strategy_name: str,
+            sell_strategy_name: str,
+            minimum_average_dollar_volume: float | None,
+            top_dollar_volume_rank: int | None = None,
+            minimum_average_dollar_volume_ratio: float | None = None,
+            starting_cash: float = 3000.0,
+            withdraw_amount: float = 0.0,
+            stop_loss_percentage: float = 1.0,
+            start_date: pandas.Timestamp | None = None,
+            allowed_fama_french_groups: set[int] | None = None,
+        ) -> StrategyMetrics:
         call_record["strategies"] = (buy_strategy_name, sell_strategy_name)
         volume_record["threshold"] = minimum_average_dollar_volume
         if minimum_average_dollar_volume_ratio is not None:
@@ -391,6 +392,7 @@ def test_start_simulate_suppresses_trade_details(
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
         start_date: pandas.Timestamp | None = None,
+        **_: object,
     ) -> StrategyMetrics:
         trade_details_by_year = {
             2023: [
@@ -470,6 +472,7 @@ def test_start_simulate_filters_early_googl_trades(
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
         start_date: pandas.Timestamp | None = None,
+        allowed_fama_french_groups: set[int] | None = None,
     ) -> StrategyMetrics:
         trade_details_by_year = {
             2013: [
@@ -572,6 +575,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
         start_date: pandas.Timestamp | None = None,
+        allowed_fama_french_groups: set[int] | None = None,
     ) -> StrategyMetrics:
         call_arguments["strategies"] = (buy_strategy_name, sell_strategy_name)
         threshold_record["threshold"] = minimum_average_dollar_volume
@@ -630,6 +634,7 @@ def test_start_simulate_accepts_start_date(monkeypatch: pytest.MonkeyPatch) -> N
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
         start_date: pandas.Timestamp | None = None,
+        allowed_fama_french_groups: set[int] | None = None,
     ) -> StrategyMetrics:
         recorded_arguments["start_date"] = start_date
         return StrategyMetrics(
@@ -1003,10 +1008,10 @@ def test_start_simulate_supports_slope_and_volume_strategy(
     )
 
 
-def test_start_simulate_accepts_slope_range_strategy_names(
+def test_start_simulate_accepts_angle_range_strategy_names(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The command should forward slope-range strategy names for evaluation."""
+    """The command should forward angle-range strategy names for evaluation."""
 
     import stock_indicator.manage as manage_module
 
@@ -1053,13 +1058,13 @@ def test_start_simulate_accepts_slope_range_strategy_names(
     shell = manage_module.StockShell(stdout=io.StringIO())
     shell.onecmd(
         "start_simulate dollar_volume>0 "
-        "ema_sma_cross_with_slope_-0.5_0.5 "
-        "ema_sma_cross_with_slope_-0.5_0.5"
+        "ema_sma_cross_with_slope_-26.6_26.6 "
+        "ema_sma_cross_with_slope_-26.6_26.6"
     )
 
     assert recorded_arguments["strategies"] == (
-        "ema_sma_cross_with_slope_-0.5_0.5",
-        "ema_sma_cross_with_slope_-0.5_0.5",
+        "ema_sma_cross_with_slope_-26.6_26.6",
+        "ema_sma_cross_with_slope_-26.6_26.6",
     )
 
 

--- a/tests/test_sma_angle.py
+++ b/tests/test_sma_angle.py
@@ -1,0 +1,32 @@
+import math
+import pandas
+import pytest
+
+import stock_indicator.strategy as strategy_module
+
+
+def test_sma_angle_computation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A known percentage change should produce the expected angle."""
+    # TODO: review
+
+    price_data_frame = pandas.DataFrame({"open": [1.0, 1.0], "close": [1.0, 1.0]})
+
+    def fake_attach(
+        data_frame: pandas.DataFrame,
+        window_size: int = 40,
+        require_close_above_long_term_sma: bool = True,
+        sma_window_factor: float | None = None,
+    ) -> None:
+        data_frame["sma_value"] = pandas.Series([100.0, 110.0])
+        data_frame["sma_previous"] = data_frame["sma_value"].shift(1)
+        data_frame["ema_sma_cross_entry_signal"] = pandas.Series([False, True])
+        data_frame["ema_sma_cross_exit_signal"] = pandas.Series([False, False])
+
+    monkeypatch.setattr(strategy_module, "attach_ema_sma_cross_signals", fake_attach)
+
+    strategy_module.attach_ema_sma_cross_with_slope_signals(
+        price_data_frame, angle_range=(-90.0, 90.0)
+    )
+
+    expected_angle = math.degrees(math.atan(0.1))
+    assert price_data_frame.loc[1, "sma_angle"] == pytest.approx(expected_angle)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -557,10 +557,10 @@ def test_evaluate_combined_strategy_passes_window_size_and_renames_columns(
     assert "ema_sma_cross_with_slope_40_exit_signal" in captured_column_names
 
 
-def test_evaluate_combined_strategy_passes_slope_range(
+def test_evaluate_combined_strategy_passes_angle_range(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The function should pass the slope range to the strategy function."""
+    """The function should pass the angle range to the strategy function."""
 
     date_index = pandas.date_range("2020-01-01", periods=2, freq="D")
     price_data_frame = pandas.DataFrame(
@@ -575,15 +575,18 @@ def test_evaluate_combined_strategy_passes_slope_range(
     price_data_frame.to_csv(csv_path, index=False)
 
     captured_arguments: dict[str, tuple[float, float] | None] = {
-        "slope_range": None
+        "angle_range": None
     }
 
     def fake_attach_signals(
         frame: pandas.DataFrame,
         window_size: int = 40,
-        slope_range: tuple[float, float] = (-0.3, 2.14),
+        angle_range: tuple[float, float] = (
+            -16.69924423399362,
+            64.95379922035721,
+        ),
     ) -> None:
-        captured_arguments["slope_range"] = slope_range
+        captured_arguments["angle_range"] = angle_range
         frame["ema_sma_cross_with_slope_entry_signal"] = [True, False]
         frame["ema_sma_cross_with_slope_exit_signal"] = [False, True]
 
@@ -611,14 +614,14 @@ def test_evaluate_combined_strategy_passes_slope_range(
 
     evaluate_combined_strategy(
         tmp_path,
-        "ema_sma_cross_with_slope_-0.5_0.5",
-        "ema_sma_cross_with_slope_-0.5_0.5",
+        "ema_sma_cross_with_slope_-26.6_26.6",
+        "ema_sma_cross_with_slope_-26.6_26.6",
     )
 
-    assert captured_arguments["slope_range"] == (-0.5, 0.5)
+    assert captured_arguments["angle_range"] == (-26.6, 26.6)
 
 
-def test_evaluate_combined_strategy_passes_slope_range_with_volume(
+def test_evaluate_combined_strategy_passes_angle_range_with_volume(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The function should pass slope range for strategies using volume."""
@@ -636,15 +639,15 @@ def test_evaluate_combined_strategy_passes_slope_range_with_volume(
     price_data_frame.to_csv(csv_path, index=False)
 
     captured_arguments: dict[str, tuple[float, float] | None] = {
-        "slope_range": None
+        "angle_range": None
     }
 
     def fake_attach_signals(
         frame: pandas.DataFrame,
         window_size: int = 40,
-        slope_range: tuple[float, float] = (-0.3, 2.14),
+        angle_range: tuple[float, float] = (-16.69924423399362, 64.95379922035721),
     ) -> None:
-        captured_arguments["slope_range"] = slope_range
+        captured_arguments["angle_range"] = angle_range
         frame["ema_sma_cross_with_slope_and_volume_entry_signal"] = [True, False]
         frame["ema_sma_cross_with_slope_and_volume_exit_signal"] = [False, True]
 
@@ -678,14 +681,14 @@ def test_evaluate_combined_strategy_passes_slope_range_with_volume(
 
     evaluate_combined_strategy(
         tmp_path,
-        "ema_sma_cross_with_slope_and_volume_-0.5_0.5",
-        "ema_sma_cross_with_slope_and_volume_-0.5_0.5",
+        "ema_sma_cross_with_slope_and_volume_-26.6_26.6",
+        "ema_sma_cross_with_slope_and_volume_-26.6_26.6",
     )
 
-    assert captured_arguments["slope_range"] == (-0.5, 0.5)
+    assert captured_arguments["angle_range"] == (-26.6, 26.6)
 
 
-def test_evaluate_combined_strategy_renames_columns_with_slope_range(
+def test_evaluate_combined_strategy_renames_columns_with_angle_range(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Signal column names should include the slope range suffix."""
@@ -702,7 +705,7 @@ def test_evaluate_combined_strategy_renames_columns_with_slope_range(
     def fake_attach_signals(
         frame: pandas.DataFrame,
         window_size: int = 40,
-        slope_range: tuple[float, float] = (-0.3, 2.14),
+        angle_range: tuple[float, float] = (-16.69924423399362, 64.95379922035721),
     ) -> None:
         frame["ema_sma_cross_with_slope_entry_signal"] = [True, False]
         frame["ema_sma_cross_with_slope_exit_signal"] = [False, True]
@@ -733,19 +736,19 @@ def test_evaluate_combined_strategy_renames_columns_with_slope_range(
 
     evaluate_combined_strategy(
         tmp_path,
-        "ema_sma_cross_with_slope_-0.5_0.5",
-        "ema_sma_cross_with_slope_-0.5_0.5",
+        "ema_sma_cross_with_slope_-26.6_26.6",
+        "ema_sma_cross_with_slope_-26.6_26.6",
     )
 
     assert (
-        "ema_sma_cross_with_slope_-0.5_0.5_entry_signal" in captured_column_names
+        "ema_sma_cross_with_slope_-26.6_26.6_entry_signal" in captured_column_names
     )
     assert (
-        "ema_sma_cross_with_slope_-0.5_0.5_exit_signal" in captured_column_names
+        "ema_sma_cross_with_slope_-26.6_26.6_exit_signal" in captured_column_names
     )
 
 
-def test_evaluate_combined_strategy_renames_columns_negative_positive_slope_range(
+def test_evaluate_combined_strategy_renames_columns_negative_positive_angle_range(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The function should include negative-to-positive slope values in names."""
@@ -762,7 +765,7 @@ def test_evaluate_combined_strategy_renames_columns_negative_positive_slope_rang
     def fake_attach_signals(
         frame: pandas.DataFrame,
         window_size: int = 40,
-        slope_range: tuple[float, float] = (-0.3, 2.14),
+        angle_range: tuple[float, float] = (-16.69924423399362, 64.95379922035721),
     ) -> None:
         frame["ema_sma_cross_with_slope_entry_signal"] = [True, False]
         frame["ema_sma_cross_with_slope_exit_signal"] = [False, True]
@@ -793,15 +796,15 @@ def test_evaluate_combined_strategy_renames_columns_negative_positive_slope_rang
 
     evaluate_combined_strategy(
         tmp_path,
-        "ema_sma_cross_with_slope_-0.1_1.2",
-        "ema_sma_cross_with_slope_-0.1_1.2",
+        "ema_sma_cross_with_slope_-5.7_50.2",
+        "ema_sma_cross_with_slope_-5.7_50.2",
     )
 
     assert (
-        "ema_sma_cross_with_slope_-0.1_1.2_entry_signal" in captured_column_names
+        "ema_sma_cross_with_slope_-5.7_50.2_entry_signal" in captured_column_names
     )
     assert (
-        "ema_sma_cross_with_slope_-0.1_1.2_exit_signal" in captured_column_names
+        "ema_sma_cross_with_slope_-5.7_50.2_exit_signal" in captured_column_names
     )
 
 def test_evaluate_combined_strategy_dollar_volume_filter(
@@ -1552,10 +1555,10 @@ def test_attach_ftd_ema_sma_cross_signals_requires_recent_ftd(
     ]
 
 
-def test_attach_ema_sma_cross_with_slope_filters_by_slope(
+def test_attach_ema_sma_cross_with_slope_filters_by_angle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The EMA/SMA cross entry applies slope filters and requires price above the SMA."""
+    """The EMA/SMA cross entry applies angle filters and requires price above the SMA."""
     # TODO: review
 
     import stock_indicator.strategy as strategy_module
@@ -1596,7 +1599,7 @@ def test_attach_ema_sma_cross_with_slope_filters_by_slope(
     )
 
     strategy_module.attach_ema_sma_cross_with_slope_signals(
-        price_data_frame, slope_range=(0.0, 0.2)
+        price_data_frame, angle_range=(0.0, 0.2), bounds_as_tangent=True
     )
 
     assert recorded_require_close_above_long_term_sma is True
@@ -1616,8 +1619,8 @@ def test_attach_ema_sma_cross_with_slope_filters_by_slope(
     ]
 
 
-def test_attach_ema_sma_cross_with_slope_signals_raises_value_error_for_invalid_slope_range() -> None:
-    """``attach_ema_sma_cross_with_slope_signals`` should validate the slope range."""
+def test_attach_ema_sma_cross_with_slope_signals_raises_value_error_for_invalid_angle_range() -> None:
+    """``attach_ema_sma_cross_with_slope_signals`` should validate the angle range."""
     # TODO: review
 
     import stock_indicator.strategy as strategy_module
@@ -1628,14 +1631,14 @@ def test_attach_ema_sma_cross_with_slope_signals_raises_value_error_for_invalid_
         ValueError, match="lower bound cannot exceed upper bound"
     ):
         strategy_module.attach_ema_sma_cross_with_slope_signals(
-            price_data_frame, slope_range=(1.0, -1.0)
+            price_data_frame, angle_range=(1.0, -1.0)
         )
 
 
-def test_attach_ema_sma_cross_testing_filters_by_slope_and_chip(
+def test_attach_ema_sma_cross_testing_filters_by_angle_and_chip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Entry applies slope and chip concentration filters without long-term SMA."""
+    """Entry applies angle and chip concentration filters without long-term SMA."""
     # TODO: review
 
     import stock_indicator.strategy as strategy_module
@@ -1695,7 +1698,7 @@ def test_attach_ema_sma_cross_testing_filters_by_slope_and_chip(
     )
 
     strategy_module.attach_ema_sma_cross_testing_signals(
-        price_data_frame, slope_range=(0.0, 0.2)
+        price_data_frame, angle_range=(0.0, 0.2), bounds_as_tangent=True
     )
 
     assert recorded_flag is False
@@ -1715,7 +1718,7 @@ def test_attach_ema_sma_cross_testing_filters_by_slope_and_chip(
     ]
 
 
-def test_attach_ema_sma_cross_testing_signals_raises_value_error_for_invalid_slope_range() -> None:
+def test_attach_ema_sma_cross_testing_signals_raises_value_error_for_invalid_angle_range() -> None:
     """``attach_ema_sma_cross_testing_signals`` should validate the slope range."""
     # TODO: review
 
@@ -1727,7 +1730,7 @@ def test_attach_ema_sma_cross_testing_signals_raises_value_error_for_invalid_slo
         ValueError, match="lower bound cannot exceed upper bound",
     ):
         strategy_module.attach_ema_sma_cross_testing_signals(
-            price_data_frame, slope_range=(1.0, -1.0)
+            price_data_frame, angle_range=(1.0, -1.0)
         )
 
 
@@ -1750,7 +1753,7 @@ def test_attach_ema_sma_cross_with_slope_and_volume_requires_higher_ema_volume(
     def fake_attach_ema_sma_cross_with_slope_signals(
         data_frame: pandas.DataFrame,
         window_size: int = 50,
-        slope_range: tuple[float, float] = (-0.3, 2.14),
+        angle_range: tuple[float, float] = (-16.69924423399362, 64.95379922035721),
     ) -> None:
         data_frame["ema_sma_cross_with_slope_entry_signal"] = pandas.Series(
             [False, True, True, True, True]
@@ -1777,7 +1780,7 @@ def test_attach_ema_sma_cross_with_slope_and_volume_requires_higher_ema_volume(
     ) == [False, False, False, False, True]
 
 
-def test_attach_ema_sma_cross_with_slope_and_volume_signals_raises_value_error_for_invalid_slope_range() -> None:
+def test_attach_ema_sma_cross_with_slope_and_volume_signals_raises_value_error_for_invalid_angle_range() -> None:
     """``attach_ema_sma_cross_with_slope_and_volume_signals`` should validate the slope range."""
     # TODO: review
 
@@ -1791,7 +1794,7 @@ def test_attach_ema_sma_cross_with_slope_and_volume_signals_raises_value_error_f
         ValueError, match="lower bound cannot exceed upper bound"
     ):
         strategy_module.attach_ema_sma_cross_with_slope_and_volume_signals(
-            price_data_frame, slope_range=(1.0, -1.0)
+            price_data_frame, angle_range=(1.0, -1.0)
         )
 
 
@@ -1944,54 +1947,54 @@ def test_supported_strategies_includes_ema_sma_double_cross() -> None:
 def test_parse_strategy_name_with_window_size() -> None:
     """``parse_strategy_name`` should parse the window size suffix."""
 
-    base_name, window_size, slope_range = parse_strategy_name(
+    base_name, window_size, angle_range = parse_strategy_name(
         "ema_sma_cross_with_slope_40"
     )
     assert base_name == "ema_sma_cross_with_slope"
     assert window_size == 40
-    assert slope_range is None
+    assert angle_range is None
 
 
-def test_parse_strategy_name_with_window_and_slope_range() -> None:
-    """The parser should extract both window size and slope range."""
+def test_parse_strategy_name_with_window_and_angle_range() -> None:
+    """The parser should extract both window size and angle range."""
 
-    base_name, window_size, slope_range = parse_strategy_name(
-        "ema_sma_cross_with_slope_40_-0.5_0.5"
+    base_name, window_size, angle_range = parse_strategy_name(
+        "ema_sma_cross_with_slope_40_-26.6_26.6"
     )
     assert base_name == "ema_sma_cross_with_slope"
     assert window_size == 40
-    assert slope_range == (-0.5, 0.5)
+    assert angle_range == (-26.6, 26.6)
 
 
-def test_parse_strategy_name_with_slope_range_only() -> None:
-    """The parser should handle slope range without window size."""
+def test_parse_strategy_name_with_angle_range_only() -> None:
+    """The parser should handle angle range without window size."""
 
-    base_name, window_size, slope_range = parse_strategy_name(
-        "ema_sma_cross_with_slope_-0.5_0.5"
+    base_name, window_size, angle_range = parse_strategy_name(
+        "ema_sma_cross_with_slope_-26.6_26.6"
     )
     assert base_name == "ema_sma_cross_with_slope"
     assert window_size is None
-    assert slope_range == (-0.5, 0.5)
+    assert angle_range == (-26.6, 26.6)
 
 
 def test_parse_strategy_name_with_integer_slope_values() -> None:
     """``parse_strategy_name`` should convert integer slope bounds to floats."""
 
-    base_name, window_size, slope_range = parse_strategy_name(
+    base_name, window_size, angle_range = parse_strategy_name(
         "ema_sma_cross_with_slope_-1_2"
     )
     assert base_name == "ema_sma_cross_with_slope"
     assert window_size is None
-    assert slope_range == (-1.0, 2.0)
+    assert angle_range == (-1.0, 2.0)
 
 
 def test_parse_strategy_name_without_suffix() -> None:
     """``parse_strategy_name`` should return ``None`` when no suffix is given."""
 
-    base_name, window_size, slope_range = parse_strategy_name("ema_sma_cross")
+    base_name, window_size, angle_range = parse_strategy_name("ema_sma_cross")
     assert base_name == "ema_sma_cross"
     assert window_size is None
-    assert slope_range is None
+    assert angle_range is None
 
 
 def test_parse_strategy_name_rejects_malformed_suffix() -> None:


### PR DESCRIPTION
## Summary
- compute SMA and EMA slopes as relative-change angles with optional tangent bounds
- clarify angle-based parameters and update documentation
- add regression test for SMA angle calculation

## Testing
- `pytest tests/test_sma_angle.py tests/test_strategy.py::test_attach_ema_sma_cross_with_slope_filters_by_angle tests/test_strategy.py::test_attach_ema_sma_cross_with_slope_signals_raises_value_error_for_invalid_angle_range tests/test_strategy.py::test_attach_ema_sma_cross_testing_filters_by_angle_and_chip -q`

------
https://chatgpt.com/codex/tasks/task_b_68b58286c030832ba8d2d204983655a6