### PR TITLE
Support per-sector pick limit for dollar volume filter

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -30,10 +30,11 @@ The optional `start` argument sets the simulation start date, `starting_cash`
 sets the initial portfolio balance, and `withdraw` deducts a fixed amount at
 each year end. The `dollar_volume` clause accepts a `>` threshold expressed in
 millions or as a percentage using `%`, and an `=Nth` ranking. When both are
-separated by a comma, the parser applies them sequentially. The command above
-first filters symbols to those whose 50-day average dollar volume exceeds
-10,000 million and then selects the six symbols with the highest remaining
-averages. The tests
+separated by a comma, the parser applies them sequentially. A trailing
+`PickM` segment allows up to `M` symbols from any single sector when a ranking
+filter is used. The command above first filters symbols to those whose 50-day
+average dollar volume exceeds 10,000 million and then selects the six symbols
+with the highest remaining averages. The tests
 `tests/test_manage.py::test_start_simulate_dollar_volume_threshold_and_rank` and
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 exercise this combined syntax.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ selects the six highest-volume symbols from the remainder. The tests
 `tests/test_strategy.py::test_evaluate_combined_strategy_dollar_volume_filter_and_rank`
 demonstrate this combined syntax.
 
+The filter optionally accepts a trailing `PickM` segment to allow multiple
+symbols from the same sector when a ranking is used. For example
+`dollar_volume>1%,Top3,Pick2` selects the top three symbols by dollar volume
+with at most two symbols drawn from any single Fama–French group.
+
 An optional stop loss value and a trailing `True` or `False` flag may be added
 after the strategy names. The numeric stop loss sets the fractional decline
 that triggers an exit on the next day's open, and the boolean flag controls

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -28,6 +28,8 @@ def test_run_daily_tasks_detects_signals(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cron, "update_symbol_cache", fake_update_symbol_cache)
     monkeypatch.setitem(strategy.SUPPORTED_STRATEGIES, "fake_strategy", fake_strategy)
+    monkeypatch.setitem(strategy.BUY_STRATEGIES, "fake_strategy", fake_strategy)
+    monkeypatch.setitem(strategy.SELL_STRATEGIES, "fake_strategy", fake_strategy)
 
     result = cron.run_daily_tasks(
         "fake_strategy",
@@ -51,12 +53,15 @@ def test_parse_daily_task_arguments_returns_expected_values():
     (
         minimum_average_dollar_volume,
         top_dollar_volume_rank,
+        maximum_symbols_per_group,
         buy_strategy_name,
         sell_strategy_name,
         stop_loss_percentage,
+        _,
     ) = cron.parse_daily_task_arguments(argument_line)
     assert minimum_average_dollar_volume == 10000.0
     assert top_dollar_volume_rank is None
+    assert maximum_symbols_per_group == 1
     assert buy_strategy_name == "ema_sma_cross"
     assert sell_strategy_name == "ema_sma_cross"
     assert stop_loss_percentage == 1.0
@@ -68,12 +73,15 @@ def test_parse_daily_task_arguments_accepts_rank() -> None:
     (
         minimum_average_dollar_volume,
         top_dollar_volume_rank,
+        maximum_symbols_per_group,
         buy_strategy_name,
         sell_strategy_name,
         stop_loss_percentage,
+        _,
     ) = cron.parse_daily_task_arguments(argument_line)
     assert minimum_average_dollar_volume is None
     assert top_dollar_volume_rank == 5
+    assert maximum_symbols_per_group == 1
     assert buy_strategy_name == "ema_sma_cross"
     assert sell_strategy_name == "ema_sma_cross"
     assert stop_loss_percentage == 1.0
@@ -85,12 +93,15 @@ def test_parse_daily_task_arguments_accepts_threshold_and_rank() -> None:
     (
         minimum_average_dollar_volume,
         top_dollar_volume_rank,
+        maximum_symbols_per_group,
         buy_strategy_name,
         sell_strategy_name,
         stop_loss_percentage,
+        _,
     ) = cron.parse_daily_task_arguments(argument_line)
     assert minimum_average_dollar_volume == 100.0
     assert top_dollar_volume_rank == 5
+    assert maximum_symbols_per_group == 1
     assert buy_strategy_name == "ema_sma_cross"
     assert sell_strategy_name == "ema_sma_cross"
     assert stop_loss_percentage == 1.0
@@ -102,12 +113,15 @@ def test_parse_daily_task_arguments_accepts_percentage() -> None:
     (
         minimum_average_dollar_volume,
         top_dollar_volume_rank,
+        maximum_symbols_per_group,
         buy_strategy_name,
         sell_strategy_name,
         stop_loss_percentage,
+        _,
     ) = cron.parse_daily_task_arguments(argument_line)
     assert minimum_average_dollar_volume == pytest.approx(0.0241)
     assert top_dollar_volume_rank is None
+    assert maximum_symbols_per_group == 1
     assert buy_strategy_name == "ema_sma_cross"
     assert sell_strategy_name == "ema_sma_cross"
     assert stop_loss_percentage == 1.0
@@ -119,12 +133,35 @@ def test_parse_daily_task_arguments_accepts_percentage_and_rank() -> None:
     (
         minimum_average_dollar_volume,
         top_dollar_volume_rank,
+        maximum_symbols_per_group,
         buy_strategy_name,
         sell_strategy_name,
         stop_loss_percentage,
+        _,
     ) = cron.parse_daily_task_arguments(argument_line)
     assert minimum_average_dollar_volume == pytest.approx(0.0241)
     assert top_dollar_volume_rank == 5
+    assert maximum_symbols_per_group == 1
+    assert buy_strategy_name == "ema_sma_cross"
+    assert sell_strategy_name == "ema_sma_cross"
+    assert stop_loss_percentage == 1.0
+
+
+def test_parse_daily_task_arguments_accepts_pick_parameter() -> None:
+    """The parser should extract the per-group pick count."""
+    argument_line = "dollar_volume>2.41%,Top3,Pick2 ema_sma_cross ema_sma_cross"
+    (
+        minimum_average_dollar_volume,
+        top_dollar_volume_rank,
+        maximum_symbols_per_group,
+        buy_strategy_name,
+        sell_strategy_name,
+        stop_loss_percentage,
+        _,
+    ) = cron.parse_daily_task_arguments(argument_line)
+    assert minimum_average_dollar_volume == pytest.approx(0.0241)
+    assert top_dollar_volume_rank == 3
+    assert maximum_symbols_per_group == 2
     assert buy_strategy_name == "ema_sma_cross"
     assert sell_strategy_name == "ema_sma_cross"
     assert stop_loss_percentage == 1.0
@@ -147,6 +184,8 @@ def test_run_daily_tasks_skips_symbol_update_errors(monkeypatch):
 
     monkeypatch.setattr(cron, "update_symbol_cache", failing_update)
     monkeypatch.setitem(strategy.SUPPORTED_STRATEGIES, "fake_strategy", fake_strategy)
+    monkeypatch.setitem(strategy.BUY_STRATEGIES, "fake_strategy", fake_strategy)
+    monkeypatch.setitem(strategy.SELL_STRATEGIES, "fake_strategy", fake_strategy)
 
     result = cron.run_daily_tasks(
         "fake_strategy",
@@ -187,6 +226,10 @@ def test_run_daily_tasks_honors_dollar_volume_rank(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cron, "update_symbol_cache", fake_update_symbol_cache)
     monkeypatch.setitem(strategy.SUPPORTED_STRATEGIES, "fake_strategy", fake_strategy)
+    monkeypatch.setitem(strategy.BUY_STRATEGIES, "fake_strategy", fake_strategy)
+    monkeypatch.setitem(strategy.SELL_STRATEGIES, "fake_strategy", fake_strategy)
+    monkeypatch.setitem(strategy.BUY_STRATEGIES, "fake_strategy", fake_strategy)
+    monkeypatch.setitem(strategy.SELL_STRATEGIES, "fake_strategy", fake_strategy)
 
     result = cron.run_daily_tasks(
         "fake_strategy",

--- a/tests/test_daily_job.py
+++ b/tests/test_daily_job.py
@@ -56,6 +56,7 @@ def test_run_daily_job_accepts_percentage(tmp_path: Path, monkeypatch: pytest.Mo
         minimum_average_dollar_volume: float | None = None,
         top_dollar_volume_rank: int | None = None,
         allowed_fama_french_groups: set[int] | None = None,
+        maximum_symbols_per_group: int = 1,
     ):
         captured_arguments["minimum_average_dollar_volume"] = minimum_average_dollar_volume
         captured_arguments["top_dollar_volume_rank"] = top_dollar_volume_rank
@@ -99,6 +100,7 @@ def test_run_daily_job_accepts_percentage_and_rank(
         minimum_average_dollar_volume: float | None = None,
         top_dollar_volume_rank: int | None = None,
         allowed_fama_french_groups: set[int] | None = None,
+        maximum_symbols_per_group: int = 1,
     ):
         captured_arguments["minimum_average_dollar_volume"] = minimum_average_dollar_volume
         captured_arguments["top_dollar_volume_rank"] = top_dollar_volume_rank


### PR DESCRIPTION
## Summary
- allow `dollar_volume` filters to include an optional `PickN` segment
- cap Top-N selections to at most N symbols per Fama–French group
- document and test the new per-group pick option

## Testing
- `pytest` *(fails: ProxyError when fetching SEC data and other environment-related errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b610bfee5c832b836f12c9f463a044