### PR TITLE
Add volume profile calculation

### DIFF
--- a/src/stock_indicator/volume_profile.py
+++ b/src/stock_indicator/volume_profile.py
@@ -1,0 +1,143 @@
+"""Utilities for computing a volume profile over a price series."""
+# TODO: review
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+import numpy
+import pandas
+
+
+@dataclass
+class VolumeProfile:
+    """Representation of a volume profile for a series of prices."""
+
+    point_of_control: float
+    value_area_high: float
+    value_area_low: float
+    bin_edges: numpy.ndarray
+    probability_distribution: numpy.ndarray
+
+
+def calculate_volume_profile(
+    ohlcv: pandas.DataFrame, lookback_window_size: int
+) -> VolumeProfile:
+    """Calculate a volume profile with adaptive bin sizing.
+
+    Parameters
+    ----------
+    ohlcv : pandas.DataFrame
+        Data frame containing ``high``, ``low``, ``close``, and ``volume`` columns.
+    lookback_window_size : int
+        Window size used to compute the average true range for determining bin width.
+
+    Returns
+    -------
+    VolumeProfile
+        A dataclass containing the point of control, value area high, value area low,
+        bin edges, and the probability distribution of volume across price levels.
+
+    Raises
+    ------
+    ValueError
+        If required columns are missing, the data frame is empty, or the lookback
+        window size is not positive.
+    """
+    required_columns = {"high", "low", "close", "volume"}
+    if not required_columns.issubset(ohlcv.columns):
+        missing = required_columns - set(ohlcv.columns)
+        raise ValueError(
+            "Data frame must contain columns: " + ", ".join(sorted(missing))
+        )
+    if ohlcv.empty:
+        raise ValueError("Input data frame must not be empty")
+    if lookback_window_size <= 0:
+        raise ValueError("lookback_window_size must be positive")
+
+    high_series = ohlcv["high"]
+    low_series = ohlcv["low"]
+    close_series = ohlcv["close"]
+    previous_close_series = close_series.shift(1)
+
+    true_range = pandas.concat(
+        [
+            high_series - low_series,
+            (high_series - previous_close_series).abs(),
+            (low_series - previous_close_series).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+
+    average_true_range = (
+        true_range.rolling(window=lookback_window_size).mean().iloc[-1]
+    )
+    highest_price = float(high_series.max())
+    lowest_price = float(low_series.min())
+    price_range = highest_price - lowest_price
+
+    if pandas.isna(average_true_range) or average_true_range <= 0:
+        bin_size = price_range * 0.05
+    else:
+        bin_size = float(average_true_range)
+    if bin_size <= 0:
+        bin_size = price_range if price_range > 0 else 1.0
+
+    number_of_bins = max(int(math.ceil(price_range / bin_size)), 1)
+
+    typical_price = (high_series + low_series) / 2
+    volume_values = ohlcv["volume"].to_numpy()
+    histogram, bin_edges = numpy.histogram(
+        typical_price,
+        bins=number_of_bins,
+        range=(lowest_price, highest_price),
+        weights=volume_values,
+    )
+    total_volume = histogram.sum()
+    if total_volume > 0:
+        probability_distribution = histogram / total_volume
+    else:
+        probability_distribution = numpy.zeros_like(histogram, dtype=float)
+
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+    point_of_control_index = int(numpy.argmax(probability_distribution))
+    point_of_control_price = float(bin_centers[point_of_control_index])
+
+    target_probability = 0.7
+    cumulative_probability = probability_distribution[point_of_control_index]
+    lower_index = point_of_control_index
+    upper_index = point_of_control_index
+    left_index = point_of_control_index - 1
+    right_index = point_of_control_index + 1
+    while (
+        cumulative_probability < target_probability
+        and (left_index >= 0 or right_index < probability_distribution.size)
+    ):
+        left_probability = (
+            probability_distribution[left_index] if left_index >= 0 else -1.0
+        )
+        right_probability = (
+            probability_distribution[right_index]
+            if right_index < probability_distribution.size
+            else -1.0
+        )
+        if right_probability >= left_probability:
+            cumulative_probability += right_probability
+            upper_index = right_index
+            right_index += 1
+        else:
+            cumulative_probability += left_probability
+            lower_index = left_index
+            left_index -= 1
+
+    value_area_low_price = float(bin_edges[lower_index])
+    value_area_high_price = float(bin_edges[upper_index + 1])
+
+    return VolumeProfile(
+        point_of_control=point_of_control_price,
+        value_area_high=value_area_high_price,
+        value_area_low=value_area_low_price,
+        bin_edges=bin_edges,
+        probability_distribution=probability_distribution,
+    )

--- a/tests/test_volume_profile.py
+++ b/tests/test_volume_profile.py
@@ -1,0 +1,39 @@
+"""Tests for the volume profile calculation."""
+# TODO: review
+
+from __future__ import annotations
+
+import numpy
+import pandas
+
+from stock_indicator.volume_profile import calculate_volume_profile, VolumeProfile
+
+
+def test_calculate_volume_profile_returns_expected_profile() -> None:
+    """The function should return a volume profile with correct key values."""
+
+    date_index = pandas.date_range("2020-01-01", periods=5, freq="D")
+    close_values = [10.0, 11.0, 12.0, 13.0, 14.0]
+    high_values = close_values
+    low_values = [value - 1.0 for value in close_values]
+    volume_values = [100, 200, 300, 200, 100]
+
+    ohlcv = pandas.DataFrame(
+        {
+            "Date": date_index,
+            "open": close_values,
+            "high": high_values,
+            "low": low_values,
+            "close": close_values,
+            "volume": volume_values,
+        }
+    )
+
+    result = calculate_volume_profile(ohlcv, lookback_window_size=5)
+
+    assert isinstance(result, VolumeProfile)
+    assert numpy.isclose(result.point_of_control, 11.5)
+    assert numpy.isclose(result.value_area_low, 10.0)
+    assert numpy.isclose(result.value_area_high, 13.0)
+    assert numpy.allclose(result.probability_distribution.sum(), 1.0)
+    assert len(result.bin_edges) == len(result.probability_distribution) + 1


### PR DESCRIPTION
## Summary
- add VolumeProfile dataclass and adaptive volume profile calculation using ATR or percentage-based bins
- test volume profile computation for expected POC and value area

## Testing
- `PYTHONPATH=src pytest tests/test_volume_profile.py`


------
https://chatgpt.com/codex/tasks/task_b_68b72270955c832b8067ae36b69af1d9