### PR TITLE
Extend strategy name parsing to support percentages

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -45,7 +45,7 @@ def _resolve_strategy_choice(raw_name: str, allowed: dict) -> str:
         if not token:
             continue
         try:
-            base_name, _, _ = strategy.parse_strategy_name(token)
+            base_name, _, _, _, _ = strategy.parse_strategy_name(token)
         except Exception:  # noqa: BLE001
             continue
         if base_name in allowed:
@@ -64,7 +64,7 @@ def _has_supported_strategy(expression: str, allowed: dict) -> bool:
         if not token:
             continue
         try:
-            base_name, _, _ = strategy.parse_strategy_name(token)
+            base_name, _, _, _, _ = strategy.parse_strategy_name(token)
         except Exception:  # noqa: BLE001
             continue
         if base_name in allowed:

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1990,54 +1990,81 @@ def test_supported_strategies_includes_ema_sma_double_cross() -> None:
 def test_parse_strategy_name_with_window_size() -> None:
     """``parse_strategy_name`` should parse the window size suffix."""
 
-    base_name, window_size, angle_range = parse_strategy_name(
+    base_name, window_size, angle_range, near_percentage, above_percentage = parse_strategy_name(
         "ema_sma_cross_with_slope_40"
     )
     assert base_name == "ema_sma_cross_with_slope"
     assert window_size == 40
     assert angle_range is None
+    assert near_percentage is None
+    assert above_percentage is None
 
 
 def test_parse_strategy_name_with_window_and_angle_range() -> None:
     """The parser should extract both window size and angle range."""
 
-    base_name, window_size, angle_range = parse_strategy_name(
+    base_name, window_size, angle_range, near_percentage, above_percentage = parse_strategy_name(
         "ema_sma_cross_with_slope_40_-26.6_26.6"
     )
     assert base_name == "ema_sma_cross_with_slope"
     assert window_size == 40
     assert angle_range == (-26.6, 26.6)
+    assert near_percentage is None
+    assert above_percentage is None
 
 
 def test_parse_strategy_name_with_angle_range_only() -> None:
     """The parser should handle angle range without window size."""
 
-    base_name, window_size, angle_range = parse_strategy_name(
+    base_name, window_size, angle_range, near_percentage, above_percentage = parse_strategy_name(
         "ema_sma_cross_with_slope_-26.6_26.6"
     )
     assert base_name == "ema_sma_cross_with_slope"
     assert window_size is None
     assert angle_range == (-26.6, 26.6)
+    assert near_percentage is None
+    assert above_percentage is None
 
 
 def test_parse_strategy_name_with_integer_slope_values() -> None:
     """``parse_strategy_name`` should convert integer slope bounds to floats."""
 
-    base_name, window_size, angle_range = parse_strategy_name(
+    base_name, window_size, angle_range, near_percentage, above_percentage = parse_strategy_name(
         "ema_sma_cross_with_slope_-1_2"
     )
     assert base_name == "ema_sma_cross_with_slope"
     assert window_size is None
     assert angle_range == (-1.0, 2.0)
+    assert near_percentage is None
+    assert above_percentage is None
+
+
+def test_parse_strategy_name_with_all_segments() -> None:
+    """The parser should handle window, angle range, and percentage thresholds."""
+
+    (
+        base_name,
+        window_size,
+        angle_range,
+        near_percentage,
+        above_percentage,
+    ) = parse_strategy_name("ema_sma_cross_with_slope_40_-26.6_26.6_0.5_1.0")
+    assert base_name == "ema_sma_cross_with_slope"
+    assert window_size == 40
+    assert angle_range == (-26.6, 26.6)
+    assert near_percentage == 0.5
+    assert above_percentage == 1.0
 
 
 def test_parse_strategy_name_without_suffix() -> None:
     """``parse_strategy_name`` should return ``None`` when no suffix is given."""
 
-    base_name, window_size, angle_range = parse_strategy_name("ema_sma_cross")
+    base_name, window_size, angle_range, near_percentage, above_percentage = parse_strategy_name("ema_sma_cross")
     assert base_name == "ema_sma_cross"
     assert window_size is None
     assert angle_range is None
+    assert near_percentage is None
+    assert above_percentage is None
 
 
 def test_parse_strategy_name_rejects_malformed_suffix() -> None:


### PR DESCRIPTION
## Summary
- expand `parse_strategy_name` to parse near/above percentage thresholds and return five values
- adjust strategy and management helpers to handle the extended tuple
- add tests covering new parsing cases

## Testing
- `PYTHONPATH=src pytest tests/test_strategy.py::test_parse_strategy_name_with_all_segments -q`
- `PYTHONPATH=src pytest tests/test_strategy.py::test_parse_strategy_name_with_window_size tests/test_strategy.py::test_parse_strategy_name_with_window_and_angle_range tests/test_strategy.py::test_parse_strategy_name_with_angle_range_only tests/test_strategy.py::test_parse_strategy_name_with_integer_slope_values tests/test_strategy.py::test_parse_strategy_name_with_all_segments tests/test_strategy.py::test_parse_strategy_name_without_suffix tests/test_strategy.py::test_parse_strategy_name_rejects_malformed_suffix -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stock_indicator')*
- `PYTHONPATH=src pytest -q` *(fails: ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68b7fe1855fc832ba13b41860f2b6a3c