### PR TITLE
Explain ema_sma_cross_testing suffix and defaults

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -112,9 +112,19 @@ start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-5.7_50.2 ema_sma_cro
 
 The testing variant `ema_sma_cross_testing` accepts the same optional window
 size and slope range suffixes. In addition to the EMA/SMA cross and slope
-filters, it recalculates chip concentration metrics and requires both the
-near-price and above-price volume ratios to remain below 0.12 and 0.10 by
-default.
+filters, it recalculates chip concentration metrics. Strategy names follow
+`ema_sma_cross_testing_<window>_<lower>_<upper>_<near>_<above>`:
+
+* `<window>` — EMA and SMA window size (default `40`).
+* `<lower>` and `<upper>` — inclusive simple moving average angle bounds in degrees (defaults `-16.7` and `65`).
+* `<near>` — maximum allowed near-price volume ratio (default `0.12`).
+* `<above>` — maximum allowed above-price volume ratio (default `0.10`).
+
+Example with custom chip concentration thresholds:
+
+```
+start_simulate dollar_volume>1 ema_sma_cross_testing_40_-16.7_65_0.2_0.15 ema_sma_cross_testing_40_-16.7_65_0.2_0.15
+```
 
 The tests `tests/test_manage.py::test_start_simulate_accepts_slope_range_strategy_names` and `tests/test_strategy.py::test_evaluate_combined_strategy_passes_slope_range` confirm this behavior. The management test shows the command accepts strategy names with slope bounds, and the strategy test verifies that the evaluation routine passes the bounds to the strategy implementation.
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,19 @@ You can combine slope bounds with a custom EMA/SMA window size by placing the in
 For experimentation, the `ema_sma_cross_testing` strategy offers the same
 optional window size and slope range suffixes. It omits the long-term simple
 moving average requirement and additionally filters signals using chip
-concentration metrics, enforcing default thresholds of 0.12 for the near-price
-volume ratio and 0.10 for the above-price volume ratio.
+concentration metrics. Strategy names follow the pattern
+`ema_sma_cross_testing_<window>_<lower>_<upper>_<near>_<above>`, where:
+
+* `<window>` — EMA and SMA window size (default `40`).
+* `<lower>` and `<upper>` — inclusive bounds for the simple moving average angle in degrees (defaults `-16.7` and `65`).
+* `<near>` — maximum fraction of volume near the current price (default `0.12`).
+* `<above>` — maximum fraction of volume above the current price (default `0.10`).
+
+Example with custom chip concentration thresholds:
+
+```bash
+(stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_testing_40_-16.7_65_0.2_0.15 ema_sma_cross_testing_40_-16.7_65_0.2_0.15
+```
 
 When omitted, the window size defaults to 40 days.
 


### PR DESCRIPTION
## Summary
- Document full `ema_sma_cross_testing_<window>_<lower>_<upper>_<near>_<above>` syntax and defaults
- Add example showing custom chip concentration thresholds

## Testing
- `PYTHONPATH=src pytest -q` *(fails: Module errors, proxy errors, and test expectations; 41 failed, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68b801aa4328832b8c19d115f5cb3ee5