### PR TITLE
Add chip concentration thresholds to test strategy

### DIFF
--- a/data/strategy_sets.csv
+++ b/data/strategy_sets.csv
@@ -2,4 +2,4 @@ strategy_id,buy,sell
 s1,ema_sma_cross_with_slope_40_-16.7_65,ema_sma_cross_with_slope_50
 s2,ema_shift_cross_with_slope_20,ema_shift_cross_with_slope_20
 s3,20_50_sma_cross,20_50_sma_cross
-s4,ema_sma_cross_testing_4_-16.7_65,ema_sma_cross_testing_5
+s4,ema_sma_cross_testing_4_-16.7_65_0.06_0.03,ema_sma_cross_testing_5_-16.7_65_0.06_0.03


### PR DESCRIPTION
## Summary
- extend ema_sma_cross_testing strategy with near and above thresholds
- ensure `strategy_sets.csv` ends with a newline

## Testing
- `PYTHONPATH=src pytest -q` *(fails: missing dependencies and proxy errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b8030d0a58832b8124d900176d0498