### PR TITLE
feat: log file and signal processing during strategy evaluation

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import logging
 import math
 from math import ceil
 from pathlib import Path
 from statistics import mean, stdev
 from typing import Callable, Dict, List
-
 import re
+
 import numpy
 import pandas
 
@@ -27,6 +28,8 @@ from .simulator import (
     simulate_trades,
 )
 from .symbols import SP500_SYMBOL
+
+LOGGER = logging.getLogger(__name__)
 
 
 DEFAULT_SMA_ANGLE_RANGE: tuple[float, float] = (
@@ -1562,6 +1565,7 @@ def evaluate_combined_strategy(
         # Build a mapping from symbol to FF12 group for filtering.
         symbol_to_group_map_for_filtering = load_ff12_groups_by_symbol()
     for csv_file_path in data_directory.glob("*.csv"):
+        LOGGER.info("loading %s", csv_file_path.stem)  # TODO: review
         if csv_file_path.stem == SP500_SYMBOL:
             continue
         if allowed_symbols is not None and csv_file_path.stem not in allowed_symbols:
@@ -1697,6 +1701,7 @@ def evaluate_combined_strategy(
         )
 
     for csv_file_path, price_data_frame, symbol_mask in selected_symbol_data:
+        LOGGER.info("building signals for %s", csv_file_path.stem)  # TODO: review
         # TODO: review
         # Build signals for all buy-side choices
         buy_signal_columns: list[str] = []


### PR DESCRIPTION
## Summary
- add module logger for strategy evaluation utilities
- log each CSV load and signal build step during combined strategy evaluation

## Testing
- `PYTHONPATH=src pytest -q` *(fails: 41 failed, 122 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68b83ac73c1c832bbf77ff7d7d44521f