### PR TITLE
Configure StockShell logging to use stdout

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -8,6 +8,7 @@ import cmd
 import datetime
 import logging
 import re
+import sys  # TODO: review
 from pathlib import Path
 from statistics import mean, stdev
 from typing import Dict, List
@@ -1416,4 +1417,8 @@ class StockShell(cmd.Cmd):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )  # TODO: review
     StockShell().cmdloop()


### PR DESCRIPTION
## Summary
- ensure stock_indicator.manage initializes logging to display INFO messages

## Testing
- `PYTHONPATH=src python -m stock_indicator.manage`
- `PYTHONPATH=src pytest` *(fails: requests.exceptions.ProxyError: HTTPSConnectionPool...)*

------
https://chatgpt.com/codex/tasks/task_b_68b83c2584c0832b855f15539d499d74