### PR TITLE
feat: add trade detail logging

### DIFF
--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -1660,3 +1660,75 @@ def test_start_simulate_creates_csv(
         "result",
         "percentage_change",
     ]
+
+
+def test_start_simulate_writes_trade_detail_log(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Trade details should be written to a log file."""
+    import stock_indicator.manage as manage_module
+
+    from stock_indicator.strategy import StrategyMetrics, TradeDetail
+
+    open_trade_detail = TradeDetail(
+        date=pandas.Timestamp("2024-01-02"),
+        symbol="AAA",
+        action="open",
+        price=10.0,
+        simple_moving_average_dollar_volume=0.0,
+        total_simple_moving_average_dollar_volume=0.0,
+        simple_moving_average_dollar_volume_ratio=0.0,
+        price_concentration_score=1.0,
+        near_price_volume_ratio=0.5,
+        above_price_volume_ratio=0.3,
+        histogram_node_count=2,
+    )
+    close_trade_detail = TradeDetail(
+        date=pandas.Timestamp("2024-01-05"),
+        symbol="AAA",
+        action="close",
+        price=12.0,
+        simple_moving_average_dollar_volume=0.0,
+        total_simple_moving_average_dollar_volume=0.0,
+        simple_moving_average_dollar_volume_ratio=0.0,
+        result="win",
+        percentage_change=0.2,
+    )
+    metrics = StrategyMetrics(
+        total_trades=1,
+        win_rate=1.0,
+        mean_profit_percentage=0.0,
+        profit_percentage_standard_deviation=0.0,
+        mean_loss_percentage=0.0,
+        loss_percentage_standard_deviation=0.0,
+        mean_holding_period=0.0,
+        holding_period_standard_deviation=0.0,
+        maximum_concurrent_positions=1,
+        maximum_drawdown=0.0,
+        final_balance=0.0,
+        compound_annual_growth_rate=0.0,
+        annual_returns={2024: 0.0},
+        annual_trade_counts={2024: 0},
+        trade_details_by_year={2024: [open_trade_detail, close_trade_detail]},
+    )
+
+    def fake_evaluate(*_: object, **__: object) -> StrategyMetrics:
+        return metrics
+
+    monkeypatch.setattr(
+        manage_module.strategy, "evaluate_combined_strategy", fake_evaluate
+    )
+    monkeypatch.chdir(tmp_path)
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd(
+        "start_simulate start=2024-01-01 dollar_volume>1 ema_sma_cross ema_sma_cross 1 false"
+    )
+
+    log_directory = tmp_path / "logs" / "trade_detail"
+    log_files = list(log_directory.glob("trade_details_*.log"))
+    assert len(log_files) == 1
+    assert log_files[0].read_text(encoding="utf-8").splitlines() == [
+        "  2024-01-02 (1) AAA open 10.00 0.0000 0.00M 0.00M price_score=1.00 near_pct=0.50 above_pct=0.30 node_count=2",
+        "  2024-01-05 (0) AAA close 12.00 0.0000 0.00M 0.00M win 20.00%",
+    ]


### PR DESCRIPTION
## Summary
- log trade details from simulations to `logs/trade_detail`
- call logging helper in multi-, single-, and N-symbol simulations
- test logging output for simulations

## Testing
- `pytest tests/test_manage.py::test_start_simulate_writes_trade_detail_log -q`
- `PYTHONPATH=src pytest -q` *(fails: Proxy errors and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68b83ddd83cc832b8ae7ff1ccd051700