### PR TITLE
Make volume profile optional in chip concentration metrics

### DIFF
--- a/src/stock_indicator/chip_filter.py
+++ b/src/stock_indicator/chip_filter.py
@@ -137,6 +137,7 @@ def calculate_chip_concentration_metrics(
     lookback_window_size: int = 60,
     bin_count: int = 50,
     near_price_band_ratio: float = 0.03,
+    include_volume_profile: bool = False,
 ) -> dict[str, float | int | None]:
     """Calculate chip concentration metrics for a price series.
 
@@ -150,6 +151,9 @@ def calculate_chip_concentration_metrics(
         Number of price bins used for the histogram.
     near_price_band_ratio : float, default 0.03
         Fractional width around the current price for the near-price band.
+    include_volume_profile : bool, default False
+        When ``True``, calculate volume profile metrics. When ``False``,
+        volume profile metrics will be ``None``.
 
     Returns
     -------
@@ -217,14 +221,24 @@ def calculate_chip_concentration_metrics(
         numpy.concatenate(([False], peak_mask, [False]))
     ) == 1
     histogram_node_count = int(numpy.sum(peak_boundaries))
-    try:
-        volume_profile = calculate_volume_profile(
-            window_frame, lookback_window_size=lookback_window_size
-        )
-        volume_profile_metrics = calculate_volume_profile_features(
-            volume_profile, current_price
-        )
-    except ValueError:
+    if include_volume_profile:
+        try:
+            volume_profile = calculate_volume_profile(
+                window_frame, lookback_window_size=lookback_window_size
+            )
+            volume_profile_metrics = calculate_volume_profile_features(
+                volume_profile, current_price
+            )
+        except ValueError:
+            volume_profile_metrics = {
+                "hhi": None,
+                "distance_to_poc": None,
+                "above_volume_ratio_vp": None,
+                "below_volume_ratio_vp": None,
+                "hvn_count": None,
+                "lvn_depth": None,
+            }
+    else:
         volume_profile_metrics = {
             "hhi": None,
             "distance_to_poc": None,

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -1067,6 +1067,7 @@ def attach_ema_sma_cross_testing_signals(
         chip_metrics = calculate_chip_concentration_metrics(
             price_data_frame.iloc[: row_index + 1],
             lookback_window_size=60,
+            include_volume_profile=False,
         )
         near_ratios.append(chip_metrics["near_price_volume_ratio"])
         above_ratios.append(chip_metrics["above_price_volume_ratio"])
@@ -1931,6 +1932,7 @@ def evaluate_combined_strategy(
             chip_metrics = calculate_chip_concentration_metrics(
                 price_data_frame.loc[: completed_trade.entry_date],
                 lookback_window_size=60,
+                include_volume_profile=False,
             )  # TODO: review
             entry_detail = TradeDetail(
                 date=completed_trade.entry_date,


### PR DESCRIPTION
## Summary
- add `include_volume_profile` flag to `calculate_chip_concentration_metrics` and compute profile metrics only when requested
- ensure strategy helpers call chip concentration metrics without volume profile by default
- expand chip filter and strategy tests for optional volume profile metrics

## Testing
- `pytest tests/test_chip_filter.py::test_calculate_chip_concentration_metrics_includes_volume_profile_metrics tests/test_chip_filter.py::test_calculate_chip_concentration_metrics_excludes_volume_profile_by_default tests/test_strategy.py::test_attach_ema_sma_cross_testing_filters_by_angle_and_chip tests/test_strategy.py::test_calculate_chip_concentration_metrics_defaults_volume_profile_to_none`


------
https://chatgpt.com/codex/tasks/task_b_68b83e302fb4832b92d2c81a53d73688