### PR TITLE
Refresh data before daily cron job

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -14,8 +14,40 @@ ARG_LINE='dollar_volume>0.05%,Top30,Pick10 strategy=s4 1.0'
 LOG_DIRECTORY="$REPOSITORY_ROOT/cron_logs"
 mkdir -p "$LOG_DIRECTORY"
 
+# Determine date range for Yahoo Finance refresh
+STOCK_DATA_DIRECTORY="$REPOSITORY_ROOT/data/stock_data"
+TODAY="$(date +%F)"
+LAST_CACHED_DATE="$("$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" <<PY
+import pandas
+from pathlib import Path
+from datetime import date
+
+stock_data_directory = Path("$STOCK_DATA_DIRECTORY")
+latest_date = None
+if stock_data_directory.exists():
+    for csv_path in stock_data_directory.glob("*.csv"):
+        try:
+            frame = pandas.read_csv(csv_path, usecols=[0], parse_dates=[0])
+        except Exception:
+            continue
+        if frame.empty:
+            continue
+        value = frame.iloc[-1, 0]
+        if hasattr(value, "date"):
+            current_date = value.date()
+            if latest_date is None or current_date > latest_date:
+                latest_date = current_date
+if latest_date is None:
+    latest_date = date.fromisoformat("2019-01-01")
+print(latest_date.isoformat())
+PY
+)"
+
 # Ensure the module can be resolved
 cd "$SOURCE_DIRECTORY"
+
+# Refresh local data cache before running the daily job
+"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage update_all_data_from_yf "$LAST_CACHED_DATE" "$TODAY" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
 
 # Run as a module so `from . import cron` works
 # Stdout/stderr go to a rolling cron log for debugging


### PR DESCRIPTION
## Summary
- update cron script to refresh Yahoo Finance data before running the daily job
- log download output to existing cron log

## Testing
- `pytest` *(fails: AssertionError, ValueError, ProxyError)*

------
https://chatgpt.com/codex/tasks/task_b_68b9589427bc832bbd43860ce33e1c33