### PR TITLE
Disable automatic breakpoints in daily job script

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -51,4 +51,5 @@ cd "$SOURCE_DIRECTORY"
 
 # Run as a module so `from . import cron` works
 # Stdout/stderr go to a rolling cron log for debugging
-"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.daily_job "$ARG_LINE" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
+# Disable automatic breakpoints during the daily job run
+PYTHONBREAKPOINT=0 "$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.daily_job "$ARG_LINE" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1


### PR DESCRIPTION
## Summary
- prevent pdb breakpoints from triggering during cron runs by setting `PYTHONBREAKPOINT=0`

## Testing
- `rg -n "Unknown syntax: EOF" cron_logs/cron_stdout.log`
- `pytest` *(fails: assert 88.99986848450366 ± 8.9e-05 == 89.0; assert 0.1889986848450367 ± 1.9e-07 == 0.189...; assert 0.20099039062670807 == 0.20099 ± 2.0e-07; ValueError: Missing operator or comma before `.`; TypeError: test_start_simulate_accepts_start_date(); TypeError: test_start_simulate_filters_pre_2014_googl(); ValueError: Unsupported strategy: kalman_filter_pyth...; AttributeError: <module 'stock_indicator.strategy_sets' from '/workspace/stock_indicator/src/stock_indicator/strategy_sets.py'> does not have attribute 'angle_filter'; TypeError: test_evaluate_combined_strategy_dollar_volume_filter_and_rank(); AttributeError: module 'stock_indicator.strategy_sets' has no attribute 'slope_and_volume_signal'; AttributeError: module 'stock_indicator.strategy_sets' has no attribute 'slope_and_volume_signal'; AttributeError: module 'stock_indicator.strategy_sets' has no attribute 'slope_and_volume_signal'; AttributeError: module 'stock_indicator.strategy_sets' has no attribute 'slope_and_volume_signal'; AttributeError: module 'stock_indicator.strategy_sets' has no attribute 'slope_and_volume_signal'; AttributeError: module 'stock_indicator.strategy_sets' has no attribute 'slope_and_volume_signal'; ImportError: cannot import name 'attach_ftd_ema_sma_cross_signals' from 'stock_indicator.strategy_sets' (/workspace/stock_indicator/src/stock_indicator/strategy_sets.py); ImportError: cannot import name 'attach_ema_sma_cross_with_slope_and_volume_signals' from 'stock_indicator.strategy_sets' (/workspace/stock_indicator/src/stock_indicator/strategy_sets.py); ImportError: cannot import name 'attach_ema_sma_double_cross_signals' from 'stock_indicator.strategy_sets' (/workspace/stock_indicator/src/stock_indicator/strategy_sets.py); requests.exceptions.ProxyError: HTTPSConnectionPool(host='www.sec.gov', port=443): Max retries exceeded with url: /files/company-submission-timestamped-index.csv?date=2022-11-14 (Caused by ProxyError('Unable to connect to proxy', RemoteDisconnected('Remote end closed connection without response')))*

------
https://chatgpt.com/codex/tasks/task_b_68ba524bd3c0832ba1aad4283ad28dd1