### PR TITLE
Handle duplicate columns in price data

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -796,6 +796,17 @@ def load_price_data(csv_file_path: Path) -> pandas.DataFrame:
         )
         for column_name in price_data_frame.columns
     ]
+    duplicate_column_mask = price_data_frame.columns.duplicated()
+    if duplicate_column_mask.any():
+        duplicate_column_names = price_data_frame.columns[
+            duplicate_column_mask
+        ].tolist()
+        LOGGER.warning(
+            "Duplicate column names %s found in %s; keeping first occurrence",
+            duplicate_column_names,
+            csv_file_path.name,
+        )
+        price_data_frame = price_data_frame.loc[:, ~duplicate_column_mask]
     required_columns = {"open", "close"}
     missing_column_names = [
         required_column


### PR DESCRIPTION
## Summary
- Deduplicate columns when loading price data and log duplicate names

## Testing
- `pytest`
- Verified `daily_job.find_signal` with `strategy=s4` on sample data

------
https://chatgpt.com/codex/tasks/task_b_68ba7791c9e0832b8f9705390f92ca3a