### PR TITLE
Document load_price_data column normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,25 @@ Downloaded data frames use lower-case ``snake_case`` column names. With
 ``yfinance`` version ``0.2.51`` and later, the ``close`` column already reflects
 dividends and stock splits, so no separate adjusted closing price column is
 provided. Downstream code should refer to columns using this standardized
-style.
+style. The ``load_price_data`` helper applies the same normalization to CSV
+files by converting headers to lowercase ``snake_case`` and stripping common
+suffixes such as ``_price``. If multiple headers normalize to the same label,
+only the first is preserved.
+
+For example, a file with the header ``Date,Open,Close,Adj Close,Close Price``
+loads as:
+
+```python
+from pathlib import Path
+from stock_indicator.strategy import load_price_data
+
+frame = load_price_data(Path("prices.csv"))
+print(frame.columns)
+# Index(['open', 'close', 'adj_close'], dtype='object')
+```
+
+Both ``Close`` and ``Close Price`` map to ``close``, so ``Close Price`` is
+discarded.
 
 ### Command Line Example
 Stock Indicator also includes a command line interface for generating trade signals from historical price data.

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -733,9 +733,13 @@ def load_price_data(csv_file_path: Path) -> pandas.DataFrame:
     """Load price data from ``csv_file_path`` and normalize column names.
 
     Duplicate dates are removed and the index is sorted to ensure that the
-    resulting frame has unique, chronologically ordered entries. When the CSV
-    file is empty, an empty data frame is returned so the caller can skip the
-    symbol gracefully.
+    resulting frame has unique, chronologically ordered entries. Column labels
+    are converted to lowercase ``snake_case`` and common suffixes such as
+    ``_price`` are stripped so that names like ``Adj Close`` or ``Close Price``
+    become ``adj_close`` and ``close``. When several columns normalize to the
+    same label, the first occurrence is retained and later duplicates are
+    discarded. When the CSV file is empty, an empty data frame is returned so
+    the caller can skip the symbol gracefully.
     """
     # TODO: review
 


### PR DESCRIPTION
## Summary
- clarify how `load_price_data` standardizes headers and drops duplicate names
- expand README with example showing `load_price_data` normalization and duplicate handling

## Testing
- `pytest` *(fails: assert 88.99986848450366 ± 8.9e-05 == 89.0, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68ba89e31608832b872e9eb68d4a14d7