### PR TITLE
Add management command to reset daily job symbols

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -1,5 +1,8 @@
 # Usage
 
+Use the `reset_symbols_daily_job` command to copy `data/symbols_yf.txt` into
+`data/symbols_daily_job.txt` when the daily job list needs to be recreated.
+
 To evaluate the FTD EMA and SMA cross strategy in the management shell, call:
 
 ```

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ python -m stock_indicator.manage
 
 (stock-indicator) update_symbols
 (stock-indicator) update_yf_symbols
+(stock-indicator) reset_symbols_daily_job
 (stock-indicator) update_data_from_yf AAPL 2024-01-01 2024-02-01
 (stock-indicator) update_all_data_from_yf 2024-01-01 2024-02-01
 (stock-indicator) exit
@@ -81,6 +82,7 @@ python -m stock_indicator.manage
 
 * `update_symbols` downloads the latest list of available ticker symbols from the SEC `company_tickers.json` dataset (via the sector pipeline integration) and writes `data/symbols.txt`.
 * `update_yf_symbols` probes Yahoo Finance for a small recent window and writes the subset of tickers that return data to `data/symbols_yf.txt`. Daily jobs require this list (no SEC fallback).
+* `reset_symbols_daily_job` copies the Yahoo Finance-ready list from `data/symbols_yf.txt` to `data/symbols_daily_job.txt`.
 * `update_data_from_yf SYMBOL START END` saves historical data for the given symbol to
   `data/<SYMBOL>.csv`.
 * `update_all_data_from_yf START END` performs the download for every cached symbol.

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -179,6 +179,27 @@ class StockShell(cmd.Cmd):
             "Use this to treat locally available CSVs as 'ready for daily jobs'.\n"
         )
 
+    def do_reset_symbols_daily_job(self, argument_line: str) -> None:  # noqa: D401
+        """reset_symbols_daily_job
+        Copy the Yahoo Finance-ready symbol list to symbols_daily_job.txt."""
+        try:
+            symbol_list = symbols.reset_daily_job_symbols()
+        except Exception as error:  # noqa: BLE001
+            self.stdout.write(f"Error: {error}\n")
+            return
+        self.stdout.write(
+            f"Daily job symbol list reset (count={len(symbol_list)})\n"
+        )
+
+    def help_reset_symbols_daily_job(self) -> None:
+        """Display help for the reset_symbols_daily_job command."""
+        self.stdout.write(
+            "reset_symbols_daily_job\n"
+            "Copy data/symbols_yf.txt to data/symbols_daily_job.txt.\n"
+            "Use this to reset the daily job symbol list from the "
+            "Yahoo Finance cache.\n"
+        )
+
     def do_update_data_from_yf(self, argument_line: str) -> None:  # noqa: D401
         """update_data_from_yf SYMBOL START END
         Download data from Yahoo Finance for SYMBOL between START and END and store as CSV."""


### PR DESCRIPTION
## Summary
- add `reset_symbols_daily_job` command to copy the Yahoo Finance symbol list to the daily job file
- document the new command in README and usage guide
- test the command to ensure the daily job file is recreated

## Testing
- `pytest tests/test_manage.py::test_reset_symbols_daily_job_command_recreates_file tests/test_symbols.py::test_reset_daily_job_symbols_copies_from_yahoo_finance_list -q`

------
https://chatgpt.com/codex/tasks/task_b_68bb1c9193c0832b95a2afa6cbb4a865