### PR TITLE
Handle errors when resetting daily job list

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -2,6 +2,7 @@
 
 Use the `reset_symbols_daily_job` command to copy `data/symbols_yf.txt` into
 `data/symbols_daily_job.txt` when the daily job list needs to be recreated.
+The command prints a confirmation or an error message.
 
 To evaluate the FTD EMA and SMA cross strategy in the management shell, call:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ python -m stock_indicator.manage
 
 * `update_symbols` downloads the latest list of available ticker symbols from the SEC `company_tickers.json` dataset (via the sector pipeline integration) and writes `data/symbols.txt`.
 * `update_yf_symbols` probes Yahoo Finance for a small recent window and writes the subset of tickers that return data to `data/symbols_yf.txt`. Daily jobs require this list (no SEC fallback).
-* `reset_symbols_daily_job` copies the Yahoo Finance-ready list from `data/symbols_yf.txt` to `data/symbols_daily_job.txt`.
+* `reset_symbols_daily_job` copies the Yahoo Finance-ready list from `data/symbols_yf.txt` to `data/symbols_daily_job.txt`. Run this when the daily job symbol file is missing or outdated.
 * `update_data_from_yf SYMBOL START END` saves historical data for the given symbol to
   `data/<SYMBOL>.csv`.
 * `update_all_data_from_yf START END` performs the download for every cached symbol.

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -184,7 +184,7 @@ class StockShell(cmd.Cmd):
         Copy the Yahoo Finance-ready symbol list to symbols_daily_job.txt."""
         try:
             symbol_list = symbols.reset_daily_job_symbols()
-        except Exception as error:  # noqa: BLE001
+        except OSError as error:
             self.stdout.write(f"Error: {error}\n")
             return
         self.stdout.write(

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -124,6 +124,28 @@ def test_reset_symbols_daily_job_command_recreates_file(
     assert output_buffer.getvalue() == "Daily job symbol list reset (count=2)\n"
 
 
+def test_reset_symbols_daily_job_command_handles_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command should report an error when the reset fails."""
+    import stock_indicator.manage as manage_module
+
+    def fake_reset_daily_job_symbols() -> list[str]:
+        raise OSError("cannot write")
+
+    monkeypatch.setattr(
+        manage_module.symbols,
+        "reset_daily_job_symbols",
+        fake_reset_daily_job_symbols,
+    )
+
+    output_buffer = io.StringIO()
+    shell = manage_module.StockShell(stdout=output_buffer)
+    shell.onecmd("reset_symbols_daily_job")
+
+    assert output_buffer.getvalue() == "Error: cannot write\n"
+
+
 # TODO: review
 def test_find_history_signal_prints_recalculated_signals(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Summary
- handle `OSError` in `reset_symbols_daily_job` shell command
- test for `reset_symbols_daily_job` command success and failure cases
- document `reset_symbols_daily_job` command in README and usage guide

## Testing
- `pytest tests/test_manage.py::test_reset_symbols_daily_job_command_recreates_file tests/test_manage.py::test_reset_symbols_daily_job_command_handles_error tests/test_symbols.py::test_reset_daily_job_symbols_copies_from_yahoo_finance_list tests/test_symbols.py::test_load_daily_job_symbols_creates_file_if_missing -q`

------
https://chatgpt.com/codex/tasks/task_b_68bb21e62410832b8d8cc4bbb8011971