### PR TITLE
Allow executing single manage command via arguments

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1609,4 +1609,8 @@ if __name__ == "__main__":
         level=logging.INFO,
         handlers=[logging.StreamHandler(sys.stdout)],
     )  # TODO: review
-    StockShell().cmdloop()
+    if sys.argv[1:]:  # TODO: review
+        command_text = " ".join(sys.argv[1:])  # TODO: review
+        StockShell().onecmd(command_text)  # TODO: review
+    else:  # TODO: review
+        StockShell().cmdloop()


### PR DESCRIPTION
## Summary
- run a single StockShell command when manage.py receives CLI arguments
- fall back to interactive shell when no arguments are provided

## Testing
- `pytest` *(fails: assert 88.99986848450366 == 89.0, ImportError: cannot import name 'attach_ftd_ema_sma_cross_signals', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68bb624b6188832bb3cc2d927943c9a8