### PR TITLE
Handle EOF in command shell

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1603,6 +1603,12 @@ class StockShell(cmd.Cmd):
         """Display help for the exit command."""
         self.stdout.write("exit\nExit the shell.\n")
 
+    # TODO: review
+    def do_EOF(self, arg: str) -> bool:
+        """Exit the shell when an end-of-file (EOF) condition is reached."""
+        self.stdout.write("Bye\n")
+        return True
+
 
 if __name__ == "__main__":
     logging.basicConfig(


### PR DESCRIPTION
## Summary
- exit the interactive shell cleanly when EOF is encountered

## Testing
- `pytest` *(fails: multiple failures in existing tests)*

------
https://chatgpt.com/codex/tasks/task_b_68bb635ac57c832b9824fdd8df325cf3