### PR TITLE
Use non-interactive stock shell

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -47,7 +47,10 @@ PY
 cd "$SOURCE_DIRECTORY"
 
 # Refresh local data cache before running the daily job
-"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage update_all_data_from_yf "$LAST_CACHED_DATE" "$TODAY" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
+"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" <<PY >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
+from stock_indicator.manage import StockShell
+StockShell().onecmd("update_all_data_from_yf $LAST_CACHED_DATE $TODAY")
+PY
 
 # Run as a module so `from . import cron` works
 # Stdout/stderr go to a rolling cron log for debugging


### PR DESCRIPTION
## Summary
- Ensure run_daily_job.sh runs the `update_all_data_from_yf` maintenance command without launching the interactive shell by calling `StockShell().onecmd(...)` directly.

## Testing
- `VENV=/root/.pyenv/versions/3.12.10 ./run_daily_job.sh`
- `rg "Unknown syntax" -n cron_logs/cron_stdout.log`
- `pytest` *(fails: 41 failed, 138 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68bb64ed6ce8832bb839948c75a54c59