### PR TITLE
Ensure find_history_signal refreshes from earliest history

### DIFF
--- a/tests/test_daily_job.py
+++ b/tests/test_daily_job.py
@@ -166,7 +166,7 @@ def test_run_daily_job_uses_oldest_data_date(tmp_path, monkeypatch):
         current_date=current_date,
     )
 
-    assert captured_start_date["value"] == "2018-06-01"
+    assert captured_start_date["value"] == "2014-01-01"
 
 
 def test_run_daily_job_expands_strategy_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Download historical data starting from the earliest cached date (or 2014-01-01 if caches begin later)
- Refresh symbol caches up to the current day before running history signals
- Adjust tests to expect 2014 fallback when no older data exists

## Testing
- `PYTHONPATH=src pytest tests/test_daily_job.py::test_run_daily_job_uses_oldest_data_date tests/test_daily_job.py::test_find_history_signal_deduplicates_cached_history -q`
- `pytest -q` *(fails: network ProxyError and numerous pre-existing assertion failures)*

------
https://chatgpt.com/codex/tasks/task_b_68bbf95a1c80832b91956ecbc85950b6