### PR TITLE
Increase file descriptor limit for daily job script

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Allow the cron job to open more file descriptors
+ulimit -n 4096
+
 # Determine repository path from script location or override with environment variables
 SCRIPT_DIRECTORY="$(cd "$(dirname "$0")" && pwd)"
 REPOSITORY_ROOT="${REPO:-$SCRIPT_DIRECTORY}"


### PR DESCRIPTION
## Summary
- raise open file descriptor limit in `run_daily_job.sh` so cron jobs can open more descriptors

## Testing
- `python -m pytest` *(fails: Unsupported strategy: fake_strategy)*

------
https://chatgpt.com/codex/tasks/task_b_68bf90f1079c832b81477052bc9f934d