### PR TITLE
feat: return unshifted signals

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -65,7 +65,9 @@ selling strategies instead.
 Each execution of the daily job records entry and exit signals in a log file in
 the project's `logs` directory using the `<YYYY-MM-DD>.log` naming convention.
 The `find_history_signal` command recalculates the signals for a specific date rather than reading the log files.
-Signal calculation uses the same group dynamic ratio and Top-N rule as `start_simulate`.
+The supplied date represents when indicator signals are produced; trades based on
+those signals execute at the next trading day's open. Signal calculation uses the
+same group dynamic ratio and Top-N rule as `start_simulate`.
 The management shell can compute signals for a specific day with either form:
 
 ```

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ python -m stock_indicator.manage
   STOP_LOSS` or `find_history_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS
   strategy=ID` recalculates the entry and exit signals for `DATE`. The first
   form supplies explicit buy and sell strategy names, while the second
-  references a strategy set identifier (see Strategy Sets below). Signal
-  calculation uses the same group dynamic ratio and Top-N rule as
-  `start_simulate`.
+  references a strategy set identifier (see Strategy Sets below). The `DATE`
+  refers to when the indicators generate signals; simulated trades occur at the
+  next trading day's open. Signal calculation uses the same group dynamic ratio
+  and Top-N rule as `start_simulate`.
 * `find_latest_signal DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY
   STOP_LOSS` or `find_latest_signal DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID`
   refreshes data for the symbols listed in `data/symbols_daily_job.txt` and

--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -519,10 +519,14 @@ def find_history_signal(
 ) -> Dict[str, Any]:
     """Run daily tasks for a single date and return signals and budget data.
 
+    The ``date_string`` represents the day on which indicator signals are
+    generated. Entries based on those signals occur on the next trading day's
+    open.
+
     Parameters
     ----------
     date_string:
-        ISO formatted date string representing the day to evaluate.
+        ISO formatted date string representing the signal date.
     dollar_volume_filter:
         Filter applied to select symbols based on dollar volume.
     buy_strategy:
@@ -562,12 +566,13 @@ def find_history_signal(
     # The downloader uses a half-open interval [start, end), therefore advance
     # the end date by one day to make the provided date inclusive.
     try:
-        evaluation_timestamp = pandas.Timestamp(date_string)
+        evaluation_timestamp = pandas.Timestamp(date_string) + pandas.Timedelta(days=1)
         end_timestamp_exclusive = evaluation_timestamp + pandas.Timedelta(days=1)
         evaluation_end_date_string = end_timestamp_exclusive.date().isoformat()
     except Exception:  # noqa: BLE001
-        evaluation_timestamp = pandas.Timestamp.today()
-        evaluation_end_date_string = date_string
+        evaluation_timestamp = pandas.Timestamp.today() + pandas.Timedelta(days=1)
+        end_timestamp_exclusive = evaluation_timestamp + pandas.Timedelta(days=1)
+        evaluation_end_date_string = end_timestamp_exclusive.date().isoformat()
     required_start = evaluation_timestamp - pandas.Timedelta(days=150)
 
     # Align symbol universe with simulator: evaluate all locally cached CSVs.

--- a/tests/test_daily_job.py
+++ b/tests/test_daily_job.py
@@ -267,10 +267,10 @@ def test_find_history_signal_returns_cron_output(
     assert signal_dictionary["exit_signals"] == expected_result["exit_signals"]
 
 
-def test_find_history_signal_detects_previous_day_crossover(
+def test_find_history_signal_detects_same_day_crossover(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """find_history_signal should detect signals when the crossover is one day earlier."""
+    """find_history_signal should detect signals on the crossover day."""
 
     data_directory = tmp_path
     csv_lines = ["Date,open,close,volume\n"]
@@ -316,7 +316,7 @@ def test_find_history_signal_detects_previous_day_crossover(
     )
 
     signal_dictionary = daily_job.find_history_signal(
-        "2024-02-21",
+        "2024-02-20",
         "dollar_volume>1",
         "20_50_sma_cross",
         "20_50_sma_cross",
@@ -408,7 +408,7 @@ def test_find_history_signal_skips_download_when_cache_covers_range(
     data_directory = tmp_path
     csv_file_path = data_directory / "AAA.csv"
     csv_file_path.write_text(
-        "Date,open,close\n2023-08-01,1,1\n2024-01-10,1,1\n", encoding="utf-8"
+        "Date,open,close\n2023-08-01,1,1\n2024-01-11,1,1\n", encoding="utf-8"
     )
 
     download_calls: list[str] = []


### PR DESCRIPTION
## Summary
- evaluate one day ahead in `find_history_signal` so the provided date reflects the actual signal day
- clarify signal-day semantics in documentation
- adjust tests for new signal-day behavior and cache coverage

## Testing
- `pytest` *(fails: assert ... , ImportError, ModuleNotFoundError, ProxyError)*


------
https://chatgpt.com/codex/tasks/task_b_68c0933082f0832bab6ede3f6df883fe