### PR TITLE
Clarify find_history_signal dates

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -64,10 +64,11 @@ selling strategies instead.
 
 Each execution of the daily job records entry and exit signals in a log file in
 the project's `logs` directory using the `<YYYY-MM-DD>.log` naming convention.
-The `find_history_signal` command recalculates the signals for a specific date rather than reading the log files.
-The supplied date represents when indicator signals are produced; trades based on
-those signals execute at the next trading day's open. Signal calculation uses the
-same group dynamic ratio and Top-N rule as `start_simulate`.
+The `find_history_signal` command recalculates the signals for a specific date
+rather than reading the log files. It reports the signals generated on the
+supplied date without shifting them to the following trading day. Trading based
+on those signals still occurs at the next trading day's open. Signal calculation
+uses the same group dynamic ratio and Top-N rule as `start_simulate`.
 The management shell can compute signals for a specific day with either form:
 
 ```
@@ -86,6 +87,12 @@ entry signals: ['AAA', 'BBB']
 exit signals: ['CCC', 'DDD']
 budget suggestions: {'AAA': 500.0, 'BBB': 500.0}
 ```
+
+In contrast, simulation commands operate on trade days. A signal produced on
+`2024-01-10` triggers a simulated trade on `2024-01-11`, while
+`find_history_signal 2024-01-10 ...` reports the signals for `2024-01-10`
+itself. This distinction helps separate signal-day lookups from trade-day
+executions.
 
 Developers may call
 `daily_job.find_history_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)`

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ python -m stock_indicator.manage
   STOP_LOSS` or `find_history_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS
   strategy=ID` recalculates the entry and exit signals for `DATE`. The first
   form supplies explicit buy and sell strategy names, while the second
-  references a strategy set identifier (see Strategy Sets below). The `DATE`
-  refers to when the indicators generate signals; simulated trades occur at the
-  next trading day's open. Signal calculation uses the same group dynamic ratio
-  and Top-N rule as `start_simulate`.
+  references a strategy set identifier (see Strategy Sets below). The command
+  now reports the signals generated on the supplied `DATE` without shifting
+  them to the next trading day. Trades based on those signals still execute at
+  the following day's open. Signal calculation uses the same group dynamic
+  ratio and Top-N rule as `start_simulate`.
 * `find_latest_signal DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY
   STOP_LOSS` or `find_latest_signal DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID`
   refreshes data for the symbols listed in `data/symbols_daily_job.txt` and
@@ -114,6 +115,19 @@ For example:
 entry signals: ['AAA', 'BBB']
 exit signals: ['CCC', 'DDD']
 budget suggestions: {'AAA': 500.0, 'BBB': 500.0}
+```
+
+Simulation commands interpret dates as trade days. A signal generated on
+`2024-01-10` leads to an order on `2024-01-11` when running `start_simulate`,
+whereas `find_history_signal 2024-01-10 ...` lists the signals produced on
+`2024-01-10` itself. This example contrasts the two modes:
+
+```bash
+(stock-indicator) start_simulate start=2024-01-10 dollar_volume>1 ema_sma_cross ema_sma_cross
+# trades execute on 2024-01-11
+(stock-indicator) find_history_signal 2024-01-10 dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
+entry signals: ['AAA']
+exit signals: ['BBB']
 ```
 
 To refresh data for the daily job symbols and compute today's signals, use


### PR DESCRIPTION
## Summary
- document that `find_history_signal` now reports signals for the requested date without next-day shifting
- illustrate the difference between simulation (trade-day) and signal lookup (signal-day)

## Testing
- `pytest` *(fails: AttributeError: module 'yfinance' has no attribute 'shared'; ProxyError: HTTPSConnectionPool(host='www.sec.gov', port=443) ...)*

------
https://chatgpt.com/codex/tasks/task_b_68c1281684bc832ba7737a9559dcbfbe