### PR TITLE
Log trade and signal dates in daily job

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -64,7 +64,9 @@ selling strategies instead.
 
 Each execution of the daily job records entry and exit signals in a log file in
 the project's `logs` directory using the `<YYYY-MM-DD>.log` naming convention.
-The `find_history_signal` command recalculates the signals for a specific date
+The filename reflects the **signal date**, and the log message notes the
+corresponding **trade date** on which those signals will execute. The
+`find_history_signal` command recalculates the signals for a specific date
 rather than reading the log files. It reports the signals generated on the
 supplied date without shifting them to the following trading day. Trading based
 on those signals still occurs at the next trading day's open. Signal calculation
@@ -87,12 +89,17 @@ entry signals: ['AAA', 'BBB']
 exit signals: ['CCC', 'DDD']
 budget suggestions: {'AAA': 500.0, 'BBB': 500.0}
 ```
+A daily job run for the same signal date writes a log entry similar to:
+
+```
+Starting daily tasks for trade date 2024-01-11 using signals from 2024-01-10
+```
 
 In contrast, simulation commands operate on trade days. A signal produced on
 `2024-01-10` triggers a simulated trade on `2024-01-11`, while
 `find_history_signal 2024-01-10 ...` reports the signals for `2024-01-10`
-itself. This distinction helps separate signal-day lookups from trade-day
-executions.
+itself. The daily job's log entry clarifies this relationship by recording both
+dates, helping separate signal-day lookups from trade-day executions.
 
 Developers may call
 `daily_job.find_history_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)`

--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -202,8 +202,14 @@ def run_daily_job(
     if log_directory is None:
         log_directory = LOG_DIRECTORY
 
-    current_date_string = current_date.isoformat()
-    LOGGER.info("Starting daily tasks for %s", current_date_string)
+    signal_date_string = current_date.isoformat()
+    trade_date = (pandas.Timestamp(current_date) + BDay(1)).date()
+    trade_date_string = trade_date.isoformat()
+    LOGGER.info(
+        "Starting daily tasks for trade date %s using signals from %s",
+        trade_date_string,
+        signal_date_string,
+    )
     normalized_argument_line = _expand_strategy_argument_line(argument_line)
 
     token_list = normalized_argument_line.split()
@@ -234,7 +240,7 @@ def run_daily_job(
     try:
         STOCK_DATA_DIRECTORY = data_directory
         signal_result: Dict[str, list[str]] = find_history_signal(
-            current_date_string,
+            signal_date_string,
             dollar_volume_filter,
             buy_strategy_name,
             sell_strategy_name,
@@ -244,7 +250,7 @@ def run_daily_job(
     finally:
         STOCK_DATA_DIRECTORY = original_stock_directory
     log_directory.mkdir(parents=True, exist_ok=True)
-    log_file_path = log_directory / f"{current_date_string}.log"
+    log_file_path = log_directory / f"{signal_date_string}.log"
     entry_signals: List[str] = signal_result.get("entry_signals", [])
     exit_signals: List[str] = signal_result.get("exit_signals", [])
 


### PR DESCRIPTION
## Summary
- Include trade and signal dates in `run_daily_job` log entry
- Document trade vs. signal date distinction in usage guide

## Testing
- `pytest` *(fails: TypeError: fake_strategy() got an unexpected keyword argument 'include_raw_signals', and other test failures)*

------
https://chatgpt.com/codex/tasks/task_b_68c15dea3610832b9058c454147a6798