### PR TITLE
Skip missing symbols lacking data

### DIFF
--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -692,10 +692,17 @@ def find_history_signal(
             if evaluation_timestamp not in history_frame.index:
                 missing_symbols.append(symbol_name)
         if missing_symbols:
-            missing_list = ", ".join(sorted(missing_symbols))
-            raise ValueError(
-                f"signals cannot be computed for {date_string}: missing data for {missing_list}"
+            warning_symbol_list = ", ".join(sorted(missing_symbols))
+            LOGGER.warning(
+                "Skipping symbols missing %s: %s",
+                date_string,
+                warning_symbol_list,
             )
+            local_symbols = [
+                symbol_name
+                for symbol_name in local_symbols
+                if symbol_name not in missing_symbols
+            ]
 
     signal_result: Dict[str, List[str]] = cron.run_daily_tasks_from_argument(
         argument_line,


### PR DESCRIPTION
## Summary
- Avoid ValueError when symbols lack data on evaluation day
- Warn and exclude missing-data symbols from daily job signals
- Test missing symbol warnings and skipped outputs

## Testing
- `pytest`
- `PYTHONPATH=src pytest tests/test_daily_job.py::test_find_history_signal_skips_missing_symbol_for_date -q`
- `PYTHONPATH=src pytest tests/test_daily_job.py::test_find_history_signal_excludes_missing_symbols_and_warns -q`


------
https://chatgpt.com/codex/tasks/task_b_68c16326c4d8832b93be71ff45b48674