### PR TITLE
Allow find_history_signal to use latest trading date

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -103,13 +103,15 @@ dates, helping separate signal-day lookups from trade-day executions.
 
 Developers may call
 `daily_job.find_history_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)`
-to compute the same values from Python code. The function returns the entry and
-exit signal lists along with the budget information when available, rather than
-reading log files.
+to compute the same values from Python code. Passing ``None`` as the first
+argument evaluates the most recent trading day. The function returns the entry
+and exit signal lists along with the budget information when available, rather
+than reading log files.
 
 To refresh data for the symbols listed in `symbols_daily_job.txt` and compute
-today's signals, use `find_latest_signal`. It accepts the same argument forms as
-`find_history_signal`:
+today's signals, use `find_latest_signal`. The command delegates to
+`daily_job.find_history_signal(None, ...)` and accepts the same argument forms
+as `find_history_signal`:
 
 ```
 find_latest_signal DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ budget suggestions: {'AAA': 500.0}
 
 Developers can also call `daily_job.find_history_signal("2024-01-10", "dollar_volume>1", "ema_sma_cross", "ema_sma_cross", 1.0)` to compute
 the same data from Python code. This function recalculates signals rather than
-reading them from log files. Signal calculation uses the same group dynamic ratio and Top-N rule as `start_simulate`.
+reading them from log files. Passing ``None`` as the first argument evaluates
+the most recent trading day. Signal calculation uses the same group dynamic
+ratio and Top-N rule as `start_simulate`.
 
 The shell can also simulate trading strategies. The `dollar_volume` filter
 accepts a minimum threshold in millions, a percentage of total market volume,

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1603,7 +1603,8 @@ class StockShell(cmd.Cmd):
         except ValueError:
             self.stdout.write("invalid stop loss\n")
             return
-        signal_data: Dict[str, Any] = daily_job.find_latest_signal(
+        signal_data: Dict[str, Any] = daily_job.find_history_signal(
+            None,
             dollar_volume_filter,
             buy_strategy_name,
             sell_strategy_name,

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -241,13 +241,15 @@ def test_find_latest_signal_prints_recalculated_signals(
 
     recorded_arguments: dict[str, object] = {}
 
-    def fake_find_latest_signal(
+    def fake_find_history_signal(
+        date_string: str | None,
         dollar_volume_filter: str,
         buy_strategy: str,
         sell_strategy: str,
         stop_loss: float,
         allowed_group_identifiers: set[int] | None = None,
     ) -> dict[str, list[str] | dict[str, float]]:
+        recorded_arguments["date"] = date_string
         recorded_arguments["filter"] = dollar_volume_filter
         recorded_arguments["buy"] = buy_strategy
         recorded_arguments["sell"] = sell_strategy
@@ -260,8 +262,8 @@ def test_find_latest_signal_prints_recalculated_signals(
 
     monkeypatch.setattr(
         manage_module.daily_job,
-        "find_latest_signal",
-        fake_find_latest_signal,
+        "find_history_signal",
+        fake_find_history_signal,
     )
 
     output_buffer = io.StringIO()
@@ -271,6 +273,7 @@ def test_find_latest_signal_prints_recalculated_signals(
     )
 
     assert recorded_arguments == {
+        "date": None,
         "filter": "dollar_volume>1",
         "buy": "ema_sma_cross",
         "sell": "ema_sma_cross",


### PR DESCRIPTION
## Summary
- allow `find_history_signal` to accept `None` and resolve to the latest trading day
- update `find_latest_signal` command to delegate to the new behavior
- refresh docs and tests to reflect the unified signal lookup

## Testing
- `python -m pytest tests/test_manage.py::test_find_latest_signal_prints_recalculated_signals tests/test_daily_job.py::test_find_history_signal_without_date_refreshes_and_computes tests/test_daily_job.py::test_find_history_signal_uses_previous_trading_day_before_market_open tests/test_daily_job.py::test_find_history_signal_logs_warning_on_yfinance_error -q`
- `python -m pytest -q` *(fails: test suite requires unavailable network resources)*

------
https://chatgpt.com/codex/tasks/task_b_68c1b5de79ac832b8ce1dd10be30a1aa