### PR TITLE
Remove deprecated latest-signal command

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -108,29 +108,23 @@ argument evaluates the most recent trading day. The function returns the entry
 and exit signal lists along with the budget information when available, rather
 than reading log files.
 
-To refresh data for the symbols listed in `symbols_daily_job.txt` and compute
-today's signals, use `find_latest_signal`. The command delegates to
-`daily_job.find_history_signal(None, ...)` and accepts the same argument forms
-as `find_history_signal`:
+To refresh data for all cached symbols and compute today's signals, run
+`find_history_signal` without a date. The command accepts the same argument
+forms:
 
 ```
-find_latest_signal DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
-find_latest_signal DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID
+find_history_signal DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
+find_history_signal DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID
 ```
 
 Example:
 
 ```
-find_latest_signal dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
+find_history_signal dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
 entry signals: ['AAA']
 exit signals: ['BBB']
 budget suggestions: {'AAA': 500.0}
 ```
-
-`find_latest_signal` updates each symbol's CSV cache before delegating to
-`find_history_signal` for the current date. Symbols that trigger
-`yfinance` errors are removed from `symbols_daily_job.txt` to prevent repeated
-failures.
 
 ## Available strategies
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ python -m stock_indicator.cli --symbol AAPL --start 2023-01-01 --end 2023-06-01 
 The package provides an interactive shell for updating the symbol cache and
 downloading historical price data. Daily tasks read the list of tracked ticker
 symbols from `data/symbols_daily_job.txt`. This file is populated with
-Yahoo Finance symbols and determines which tickers the daily job and the
-`find_latest_signal` command process. Regenerate it from `data/symbols_yf.txt`
-whenever the list is missing or outdated.
+Yahoo Finance symbols and determines which tickers the daily job processes.
+Regenerate it from `data/symbols_yf.txt` whenever the list is missing or
+outdated.
 
 ```bash
 python -m stock_indicator.manage
@@ -88,25 +88,21 @@ python -m stock_indicator.manage
 * `update_yf_symbols` probes Yahoo Finance for a small recent window and writes the subset of tickers that return data to `data/symbols_yf.txt`. Daily jobs require this list (no SEC fallback).
 * `reset_symbols_daily_job` copies the Yahoo Finance-ready list from
   `data/symbols_yf.txt` to `data/symbols_daily_job.txt`. The resulting file
-  defines which symbols the daily job and `find_latest_signal` process. Run this
-  when the daily job symbol file is missing or outdated.
+  defines which symbols the daily job processes. Run this when the daily job
+  symbol file is missing or outdated.
 * `update_data_from_yf SYMBOL START END` saves historical data for the given symbol to
   `data/<SYMBOL>.csv`.
 * `update_all_data_from_yf START END` performs the download for every cached symbol.
-* `find_history_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY
-  STOP_LOSS` or `find_history_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS
+* `find_history_signal [DATE] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY
+  STOP_LOSS` or `find_history_signal [DATE] DOLLAR_VOLUME_FILTER STOP_LOSS
   strategy=ID` recalculates the entry and exit signals for `DATE`. The first
   form supplies explicit buy and sell strategy names, while the second
-  references a strategy set identifier (see Strategy Sets below). The command
-  now reports the signals generated on the supplied `DATE` without shifting
-  them to the next trading day. Trades based on those signals still execute at
-  the following day's open. Signal calculation uses the same group dynamic
-  ratio and Top-N rule as `start_simulate`.
-* `find_latest_signal DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY
-  STOP_LOSS` or `find_latest_signal DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID`
-  refreshes data for the symbols listed in `data/symbols_daily_job.txt` and
-  computes today's entry and exit signals. Symbols that trigger
-  `yfinance` errors are removed from the daily job list.
+  references a strategy set identifier (see Strategy Sets below). Omitting
+  `DATE` refreshes data for all cached symbols and evaluates the most recent
+  trading day. The command now reports the signals generated on the supplied
+  day without shifting them to the next trading day. Trades based on those
+  signals still execute at the following day's open. Signal calculation uses
+  the same group dynamic ratio and Top-N rule as `start_simulate`.
 
 For example:
 
@@ -130,11 +126,11 @@ entry signals: ['AAA']
 exit signals: ['BBB']
 ```
 
-To refresh data for the daily job symbols and compute today's signals, use
-`find_latest_signal`:
+To refresh data for all cached symbols and compute today's signals, run
+`find_history_signal` without a date:
 
 ```bash
-(stock-indicator) find_latest_signal dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
+(stock-indicator) find_history_signal dollar_volume>1 ema_sma_cross ema_sma_cross 1.0
 entry signals: ['AAA']
 exit signals: ['BBB']
 budget suggestions: {'AAA': 500.0}

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1444,16 +1444,16 @@ class StockShell(cmd.Cmd):
 
     # TODO: review
     def do_find_history_signal(self, argument_line: str) -> None:  # noqa: D401
-        """find_history_signal DATE DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
-        [group=...] or find_history_signal DATE DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID
+        """find_history_signal [DATE] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS
+        [group=...] or find_history_signal [DATE] DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID
         [group=...]
 
-        Display the entry and exit signals generated for DATE."""
+        Display the entry and exit signals generated for DATE or the latest trading day when DATE is omitted."""
         usage_message = (
-            "usage: find_history_signal DATE DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
+            "usage: find_history_signal [DATE] DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
         )
         argument_parts: List[str] = argument_line.split()
-        if len(argument_parts) < 4:
+        if len(argument_parts) < 3:
             self.stdout.write(usage_message)
             return  # TODO: review
         # Optional group token may appear in any position after DATE; normalize
@@ -1480,15 +1480,19 @@ class StockShell(cmd.Cmd):
                 strategy_id = token.split("=", 1)[1].strip()
             else:
                 tokens.append(token)
+        try:
+            datetime.date.fromisoformat(tokens[0])
+            date_string = tokens.pop(0)
+        except ValueError:
+            date_string = None
         # Support two forms:
-        # 1) DATE FILTER BUY SELL STOP
-        # 2) DATE FILTER STOP with strategy=ID
+        # 1) [DATE] FILTER BUY SELL STOP
+        # 2) [DATE] FILTER STOP with strategy=ID
         if strategy_id:
-            if len(tokens) != 3:
+            if len(tokens) != 2:
                 self.stdout.write(usage_message)
                 return
             (
-                date_string,
                 dollar_volume_filter,
                 stop_loss_string,
             ) = tokens
@@ -1498,21 +1502,21 @@ class StockShell(cmd.Cmd):
                 return
             buy_strategy_name, sell_strategy_name = mapping[strategy_id]
         else:
-            if len(tokens) != 5:
+            if len(tokens) != 4:
                 self.stdout.write(usage_message)
                 return
             (
-                date_string,
                 dollar_volume_filter,
                 buy_strategy_name,
                 sell_strategy_name,
                 stop_loss_string,
             ) = tokens
-        try:
-            datetime.date.fromisoformat(date_string)
-        except ValueError:
-            self.stdout.write(usage_message)
-            return
+        if date_string is not None:
+            try:
+                datetime.date.fromisoformat(date_string)
+            except ValueError:
+                self.stdout.write(usage_message)
+                return
         try:
             stop_loss_value = float(stop_loss_string)
         except ValueError:
@@ -1538,95 +1542,11 @@ class StockShell(cmd.Cmd):
     def help_find_history_signal(self) -> None:
         """Display help for the find_history_signal command."""
         self.stdout.write(
-            "find_history_signal DATE DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
-            "Display entry and exit signals for DATE using the provided strategies or a strategy id from data/strategy_sets.csv.\n"
+            "find_history_signal [DATE] DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
+            "Display entry and exit signals for DATE or the latest trading day when DATE is omitted using the provided strategies or a strategy id from data/strategy_sets.csv.\n"
             "Signal calculation uses the same group dynamic ratio and Top-N rule as start_simulate.\n"
         )
 
-    # TODO: review
-    def do_find_latest_signal(self, argument_line: str) -> None:  # noqa: D401
-        """find_latest_signal DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY STOP_LOSS [group=...]
-        or find_latest_signal DOLLAR_VOLUME_FILTER STOP_LOSS strategy=ID [group=...]"""
-
-        usage_message = (
-            "usage: find_latest_signal DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
-        )
-        argument_parts: List[str] = argument_line.split()
-        if len(argument_parts) < 3:
-            self.stdout.write(usage_message)
-            return
-        allowed_group_identifiers: set[int] | None = None
-        tokens: List[str] = []
-        strategy_id: str | None = None
-        for token in argument_parts:
-            if token.startswith("group="):
-                try:
-                    raw = token.split("=", 1)[1]
-                    parts = [p.strip() for p in raw.split(",") if p.strip()]
-                    parsed = {int(p) for p in parts}
-                except ValueError:
-                    self.stdout.write("invalid group list\n")
-                    return
-                if any(identifier < 1 or identifier > 11 for identifier in parsed):
-                    self.stdout.write("group identifiers must be between 1 and 11\n")
-                    return
-                if 12 in parsed:
-                    self.stdout.write("group list must not include 12 (Other)\n")
-                    return
-                allowed_group_identifiers = parsed
-            elif token.startswith("strategy="):
-                strategy_id = token.split("=", 1)[1].strip()
-            else:
-                tokens.append(token)
-        if strategy_id:
-            if len(tokens) != 2:
-                self.stdout.write(usage_message)
-                return
-            dollar_volume_filter, stop_loss_string = tokens
-            mapping = load_strategy_set_mapping()
-            if strategy_id not in mapping:
-                self.stdout.write(f"unknown strategy id: {strategy_id}\n")
-                return
-            buy_strategy_name, sell_strategy_name = mapping[strategy_id]
-        else:
-            if len(tokens) != 4:
-                self.stdout.write(usage_message)
-                return
-            (
-                dollar_volume_filter,
-                buy_strategy_name,
-                sell_strategy_name,
-                stop_loss_string,
-            ) = tokens
-        try:
-            stop_loss_value = float(stop_loss_string)
-        except ValueError:
-            self.stdout.write("invalid stop loss\n")
-            return
-        signal_data: Dict[str, Any] = daily_job.find_history_signal(
-            None,
-            dollar_volume_filter,
-            buy_strategy_name,
-            sell_strategy_name,
-            stop_loss_value,
-            allowed_group_identifiers,
-        )
-        entry_signal_list: List[str] = signal_data.get("entry_signals", [])
-        exit_signal_list: List[str] = signal_data.get("exit_signals", [])
-        self.stdout.write(f"entry signals: {entry_signal_list}\n")
-        self.stdout.write(f"exit signals: {exit_signal_list}\n")
-        entry_budgets: Dict[str, float] | None = signal_data.get("entry_budgets")
-        if entry_budgets:
-            self.stdout.write(f"budget suggestions: {entry_budgets}\n")
-
-    # TODO: review
-    def help_find_latest_signal(self) -> None:
-        """Display help for the find_latest_signal command."""
-        self.stdout.write(
-            "find_latest_signal DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
-            "Display entry and exit signals for the most recent date using the provided strategies or a strategy id from data/strategy_sets.csv.\n"
-            "Signal calculation uses the same group dynamic ratio and Top-N rule as start_simulate.\n"
-        )
 
 
     def do_exit(self, argument_line: str) -> bool:  # noqa: D401

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -231,9 +231,9 @@ def test_find_history_signal_prints_recalculated_signals(
         "budget suggestions: {'AAA': 500.0}",
     ]
 
-
+ 
 # TODO: review
-def test_find_latest_signal_prints_recalculated_signals(
+def test_find_history_signal_without_date_prints_recalculated_signals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The command should display latest signals and budget suggestions."""
@@ -269,7 +269,7 @@ def test_find_latest_signal_prints_recalculated_signals(
     output_buffer = io.StringIO()
     shell = manage_module.StockShell(stdout=output_buffer)
     shell.onecmd(
-        "find_latest_signal dollar_volume>1 ema_sma_cross ema_sma_cross 1.0",
+        "find_history_signal dollar_volume>1 ema_sma_cross ema_sma_cross 1.0",
     )
 
     assert recorded_arguments == {
@@ -320,7 +320,7 @@ def test_find_history_signal_invalid_argument(
     assert (
         output_buffer.getvalue()
         ==
-        "usage: find_history_signal DATE DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
+        "usage: find_history_signal [DATE] DOLLAR_VOLUME_FILTER (BUY SELL STOP_LOSS | STOP_LOSS strategy=ID) [group=1,2,...]\n"
     )
 
 


### PR DESCRIPTION
## Summary
- drop obsolete `find_latest_signal` implementation and management shell commands
- allow `find_history_signal` to run without a date for latest signals
- document `find_history_signal` as replacement for `find_latest_signal`

## Testing
- `pytest`
- `pytest tests/test_manage.py::test_find_history_signal_without_date_prints_recalculated_signals tests/test_manage.py::test_find_history_signal_invalid_argument -q`


------
https://chatgpt.com/codex/tasks/task_b_68c1b81c3590832bb1d65101f75684ad