### PR TITLE
Update daily job script for manager CLI workflow

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -10,16 +10,25 @@ REPOSITORY_ROOT="${REPO:-$SCRIPT_DIRECTORY}"
 SOURCE_DIRECTORY="${SRC:-$REPOSITORY_ROOT/src}"
 VIRTUAL_ENVIRONMENT_DIRECTORY="${VENV:-$REPOSITORY_ROOT/venv}"
 
-# Your daily_job argument line:
+# Your daily_job argument line
 ARG_LINE='dollar_volume>0.05%,Top30,Pick10 strategy=s4 1.0'
 
-# Set up logging directory
+# Set up logging directories
 LOG_DIRECTORY="$REPOSITORY_ROOT/cron_logs"
-mkdir -p "$LOG_DIRECTORY"
+DATE_LOG_DIRECTORY="$REPOSITORY_ROOT/logs"
+mkdir -p "$LOG_DIRECTORY" "$DATE_LOG_DIRECTORY"
 
 # Ensure the module can be resolved
 cd "$SOURCE_DIRECTORY"
 
-# Run as a module so `from . import cron` works
-# Stdout/stderr go to a rolling cron log for debugging
-"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.daily_job "$ARG_LINE" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
+# TODO: review - compute the latest trading date and one-year start date
+LATEST_DATE="$("$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -c 'from stock_indicator.daily_job import determine_latest_trading_date as determine_date;print(determine_date())')"
+START_DATE="$(date -d "$LATEST_DATE -1 year" +%F)"
+
+# Update historical data and record signals
+"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage update_all_data_from_yf "$START_DATE" "$LATEST_DATE" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
+"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage find_history_signal "$LATEST_DATE" "$ARG_LINE" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
+
+# Write a marker file for the latest run
+# TODO: review
+: > "$DATE_LOG_DIRECTORY/$LATEST_DATE.log"


### PR DESCRIPTION
## Summary
- compute latest trading date and one-year start date
- run manager CLI tasks to update data and find signals
- write marker file for the latest run

## Testing
- `python -m stock_indicator.manage update_all_data_from_yf "$START_DATE" "$LATEST_DATE"` *(failed: KeyboardInterrupt)*
- `python -m stock_indicator.manage find_history_signal "$LATEST_DATE" "$ARG_LINE"`
- `pytest` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68c29f68303c832bbd9b1a5a010663ee