### PR TITLE
refactor: remove legacy cron entry

### DIFF
--- a/src/stock_indicator/cron.py
+++ b/src/stock_indicator/cron.py
@@ -1,4 +1,8 @@
-"""Scheduled daily tasks for updating data and evaluating strategies."""
+"""Helpers for parsing daily-job arguments and executing tasks.
+
+This module contains only lightweight utilities used by ``daily_job`` and
+related modules. Scheduling responsibilities are handled elsewhere.
+"""
 # TODO: review
 
 from __future__ import annotations
@@ -257,67 +261,3 @@ def run_daily_tasks(
     )
 
 
-def run_daily_tasks_from_argument(
-    argument_line: str,
-    start_date: str,
-    end_date: str,
-    symbol_list: Iterable[str] | None = None,
-    data_download_function: Callable[[str, str, str], pandas.DataFrame] = download_history,
-    data_directory: Path | None = None,
-    use_unshifted_signals: bool = False,
-) -> Dict[str, List[str]]:
-    """Run daily tasks using a single argument string.
-
-    Parameters
-    ----------
-    argument_line: str
-        Argument string in the format accepted by
-        :func:`parse_daily_task_arguments`.
-    start_date: str
-        Start date for downloading historical data in ``YYYY-MM-DD`` format.
-    end_date: str
-        End date for downloading historical data in ``YYYY-MM-DD`` format.
-    symbol_list: Iterable[str] | None
-        Iterable of ticker symbols to process. When ``None``, the local symbol
-        cache is updated and used.
-    data_download_function: Callable[[str, str, str], pandas.DataFrame]
-        Function responsible for retrieving historical price data. Defaults to
-        :func:`download_history`.
-    data_directory: Path | None
-        Optional directory path where downloaded data is stored as CSV files.
-    use_unshifted_signals: bool, optional
-        When ``True``, evaluate unshifted columns with the
-        ``*_raw_entry_signal`` and ``*_raw_exit_signal`` suffixes.
-
-    Returns
-    -------
-    Dict[str, List[str]]
-        Dictionary with ``entry_signals`` and ``exit_signals`` listing symbols
-        that triggered the respective signals on the latest available data row.
-    """
-    (
-        minimum_average_dollar_volume,
-        top_dollar_volume_rank,
-        maximum_symbols_per_group,
-        buy_strategy_name,
-        sell_strategy_name,
-        _,
-        allowed_groups,
-    ) = parse_daily_task_arguments(argument_line)
-    extra_kwargs: dict[str, object] = {}
-    if maximum_symbols_per_group != 1:
-        extra_kwargs["maximum_symbols_per_group"] = maximum_symbols_per_group
-    return run_daily_tasks(
-        buy_strategy_name=buy_strategy_name,
-        sell_strategy_name=sell_strategy_name,
-        start_date=start_date,
-        end_date=end_date,
-        symbol_list=symbol_list,
-        data_download_function=data_download_function,
-        data_directory=data_directory,
-        minimum_average_dollar_volume=minimum_average_dollar_volume,
-        top_dollar_volume_rank=top_dollar_volume_rank,
-        allowed_fama_french_groups=allowed_groups,
-        use_unshifted_signals=use_unshifted_signals,
-        **extra_kwargs,
-    )

--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo
 import pandas
 from pandas.tseries.offsets import BDay
 
-from . import cron
+from .cron import parse_daily_task_arguments, run_daily_tasks
 from .data_loader import download_history, load_local_history
 from .symbols import SP500_SYMBOL, load_symbols
 
@@ -245,13 +245,27 @@ def find_history_signal(
                 for symbol_name in local_symbols
                 if symbol_name not in missing_symbols
             ]
-    signal_result: Dict[str, List[str]] = cron.run_daily_tasks_from_argument(
-        argument_line,
+    (
+        minimum_average_dollar_volume,
+        top_dollar_volume_rank,
+        maximum_symbols_per_group,
+        parsed_buy_strategy,
+        parsed_sell_strategy,
+        _,
+        allowed_groups,
+    ) = parse_daily_task_arguments(argument_line)
+    signal_result: Dict[str, List[str]] = run_daily_tasks(
+        buy_strategy_name=parsed_buy_strategy,
+        sell_strategy_name=parsed_sell_strategy,
         start_date=start_date_string,
         end_date=evaluation_end_date_string,
         symbol_list=local_symbols,
         data_download_function=load_local_history,
         data_directory=STOCK_DATA_DIRECTORY,
+        minimum_average_dollar_volume=minimum_average_dollar_volume,
+        top_dollar_volume_rank=top_dollar_volume_rank,
+        allowed_fama_french_groups=allowed_groups,
+        maximum_symbols_per_group=maximum_symbols_per_group,
         use_unshifted_signals=True,
     )
     entry_signals = signal_result.get("entry_signals", [])

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -155,20 +155,13 @@ def test_find_history_signal_prints_recalculated_signals(
 
     recorded_arguments: dict[str, object] = {}
 
-    def fake_run_daily_tasks_from_argument(
-        argument_line: str,
-        start_date: str,
-        end_date: str,
-        symbol_list=None,
-        data_directory: Path | None = None,
-        use_unshifted_signals: bool = False,
-    ) -> dict[str, list[str]]:
+    def fake_run_daily_tasks(*args, **kwargs) -> dict[str, list[str]]:
         return {"entry_signals": ["AAA"], "exit_signals": ["BBB"]}
 
     monkeypatch.setattr(
-        manage_module.daily_job.cron,
-        "run_daily_tasks_from_argument",
-        fake_run_daily_tasks_from_argument,
+        manage_module.daily_job,
+        "run_daily_tasks",
+        fake_run_daily_tasks,
     )
     monkeypatch.setattr(
         manage_module.daily_job,


### PR DESCRIPTION
## Summary
- drop unused cron helpers tied to legacy scheduling
- update daily job to parse arguments and call run_daily_tasks directly
- adjust tests and imports for the reduced API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c2b2564c64832b9206decf2c926d22