### PR TITLE
Treat end date as inclusive for Yahoo Finance downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ python -m stock_indicator.manage
   defines which symbols the daily job processes. Run this when the daily job
   symbol file is missing or outdated.
 * `update_data_from_yf SYMBOL START END` saves historical data for the given symbol to
-  `data/<SYMBOL>.csv`.
+  `data/<SYMBOL>.csv`. ``END`` is inclusive.
 * `update_all_data_from_yf START END` performs the download for every cached symbol.
+  ``END`` is inclusive.
 * `find_history_signal [DATE] DOLLAR_VOLUME_FILTER BUY_STRATEGY SELL_STRATEGY
   STOP_LOSS` or `find_history_signal [DATE] DOLLAR_VOLUME_FILTER STOP_LOSS
   strategy=ID` recalculates the entry and exit signals for `DATE`. The first

--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -121,8 +121,16 @@ def determine_last_cached_date(data_directory: Path) -> datetime.date:
 def update_all_data_from_yf(
     start_date: str, end_date: str, data_directory: Path
 ) -> None:
-    """Download historical data for all symbols into ``data_directory``."""
+    """Download historical data for all symbols into ``data_directory``.
 
+    The ``end_date`` argument is treated as inclusive. To accommodate the
+    exclusive end-date semantics of the Yahoo Finance API, this function adds
+    one day to ``end_date`` before requesting data.
+    """
+
+    exclusive_end_date = (
+        datetime.date.fromisoformat(end_date) + datetime.timedelta(days=1)
+    ).isoformat()
     symbol_list = load_symbols()
     if SP500_SYMBOL not in symbol_list:
         symbol_list.append(SP500_SYMBOL)
@@ -130,7 +138,10 @@ def update_all_data_from_yf(
         csv_path = data_directory / f"{symbol_name}.csv"
         try:
             download_history(
-                symbol_name, start=start_date, end=end_date, cache_path=csv_path
+                symbol_name,
+                start=start_date,
+                end=exclusive_end_date,
+                cache_path=csv_path,
             )
             try:
                 cached_frame = pandas.read_csv(


### PR DESCRIPTION
## Summary
- Ensure update_all_data_from_yf treats END date as inclusive by adding one day before calling Yahoo Finance
- Align CLI commands, docs, and tests with inclusive END semantics
- Add regression tests verifying inclusive end date handling

## Testing
- `pytest` *(fails: requests.exceptions.ProxyError, ImportError, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68c2cb31327c832b86651f77d444e102