### PR TITLE
Add filter debug values command and helper

### DIFF
--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -372,6 +372,131 @@ def test_find_history_signal_with_strategy_id(
     }
 
 
+# TODO: review
+def test_filter_debug_values_prints_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command should display indicator debug values for a symbol."""
+    import stock_indicator.manage as manage_module
+
+    recorded_arguments: dict[str, object] = {}
+
+    def fake_filter_debug_values(
+        symbol_name: str,
+        date_string: str,
+        buy_name: str,
+        sell_name: str,
+    ) -> dict[str, object]:
+        recorded_arguments["symbol"] = symbol_name
+        recorded_arguments["date"] = date_string
+        recorded_arguments["buy"] = buy_name
+        recorded_arguments["sell"] = sell_name
+        return {
+            "sma_angle": 1.0,
+            "near_price_volume_ratio": 0.2,
+            "above_price_volume_ratio": 0.3,
+            "entry": True,
+            "exit": False,
+        }
+
+    monkeypatch.setattr(
+        manage_module.daily_job,
+        "filter_debug_values",
+        fake_filter_debug_values,
+    )
+
+    output_buffer = io.StringIO()
+    shell = manage_module.StockShell(stdout=output_buffer)
+    shell.onecmd(
+        "filter_debug_values AAA 2024-01-10 ema_sma_cross ema_sma_cross",
+    )
+
+    assert recorded_arguments == {
+        "symbol": "AAA",
+        "date": "2024-01-10",
+        "buy": "ema_sma_cross",
+        "sell": "ema_sma_cross",
+    }
+    expected_output = pandas.DataFrame(
+        [
+            {
+                "date": "2024-01-10",
+                "sma_angle": 1.0,
+                "near_price_volume_ratio": 0.2,
+                "above_price_volume_ratio": 0.3,
+                "entry": True,
+                "exit": False,
+            }
+        ]
+    ).to_string(index=False)
+    assert output_buffer.getvalue() == expected_output + "\n"
+
+
+# TODO: review
+def test_filter_debug_values_with_strategy_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command should map a strategy id to buy and sell names."""
+    import stock_indicator.manage as manage_module
+
+    recorded_arguments: dict[str, object] = {}
+
+    def fake_filter_debug_values(
+        symbol_name: str,
+        date_string: str,
+        buy_name: str,
+        sell_name: str,
+    ) -> dict[str, object]:
+        recorded_arguments["symbol"] = symbol_name
+        recorded_arguments["date"] = date_string
+        recorded_arguments["buy"] = buy_name
+        recorded_arguments["sell"] = sell_name
+        return {
+            "sma_angle": 1.0,
+            "near_price_volume_ratio": 0.2,
+            "above_price_volume_ratio": 0.3,
+            "entry": True,
+            "exit": False,
+        }
+
+    monkeypatch.setattr(
+        manage_module.daily_job,
+        "filter_debug_values",
+        fake_filter_debug_values,
+    )
+
+    def fake_load_mapping() -> dict[str, tuple[str, str]]:
+        return {"TEST": ("ema_sma_cross", "ema_sma_cross")}
+
+    monkeypatch.setattr(
+        manage_module, "load_strategy_set_mapping", fake_load_mapping
+    )
+
+    output_buffer = io.StringIO()
+    shell = manage_module.StockShell(stdout=output_buffer)
+    shell.onecmd("filter_debug_values AAA 2024-01-10 strategy=TEST")
+
+    assert recorded_arguments == {
+        "symbol": "AAA",
+        "date": "2024-01-10",
+        "buy": "ema_sma_cross",
+        "sell": "ema_sma_cross",
+    }
+    expected_output = pandas.DataFrame(
+        [
+            {
+                "date": "2024-01-10",
+                "sma_angle": 1.0,
+                "near_price_volume_ratio": 0.2,
+                "above_price_volume_ratio": 0.3,
+                "entry": True,
+                "exit": False,
+            }
+        ]
+    ).to_string(index=False)
+    assert output_buffer.getvalue() == expected_output + "\n"
+
+
     
 
 


### PR DESCRIPTION
## Summary
- add `daily_job.filter_debug_values` to inspect indicator components for a date and symbol
- expose `filter_debug_values` command in manage shell with strategy-id support
- cover command parsing and output with new unit tests

## Testing
- `pytest tests/test_manage.py::test_filter_debug_values_prints_table tests/test_manage.py::test_filter_debug_values_with_strategy_id -q`

------
https://chatgpt.com/codex/tasks/task_b_68c2db8fd904832b920452d348601858