### PR TITLE
Return eligible symbols with groups for history signals

### DIFF
--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -201,8 +201,9 @@ def find_history_signal(
 
     Returns
     -------
-    Dict[str, List[str]]
-        Dictionary with ``entry_signals`` and ``exit_signals`` lists.
+    Dict[str, List[str] | List[tuple[str, int | None]]]
+        Dictionary containing ``filtered_symbols`` (pairs of symbol and
+        Fama–French group identifiers), ``entry_signals`` and ``exit_signals``.
     """
 
     # TODO: review
@@ -266,7 +267,7 @@ def find_history_signal(
         _,
         allowed_groups,
     ) = parse_daily_task_arguments(argument_line)
-    signal_result: Dict[str, List[str]] = run_daily_tasks(
+    signal_result: Dict[str, List[str] | List[tuple[str, int | None]]] = run_daily_tasks(
         buy_strategy_name=parsed_buy_strategy,
         sell_strategy_name=parsed_sell_strategy,
         start_date=start_date_string,
@@ -282,7 +283,12 @@ def find_history_signal(
     )
     entry_signals = signal_result.get("entry_signals", [])
     exit_signals = signal_result.get("exit_signals", [])
-    return {"entry_signals": entry_signals, "exit_signals": exit_signals}
+    filtered_symbols = signal_result.get("filtered_symbols", [])
+    return {
+        "filtered_symbols": filtered_symbols,
+        "entry_signals": entry_signals,
+        "exit_signals": exit_signals,
+    }
 
 
 def filter_debug_values(

--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1585,6 +1585,11 @@ class StockShell(cmd.Cmd):
             stop_loss_value,
             allowed_group_identifiers,
         )
+        filtered_symbol_list: List[tuple[str, int | None]] = signal_data.get(
+            "filtered_symbols", []
+        )
+        if filtered_symbol_list:
+            self.stdout.write(f"filtered symbols: {filtered_symbol_list}\n")
         entry_signal_list: List[str] = signal_data.get("entry_signals", [])
         exit_signal_list: List[str] = signal_data.get("exit_signals", [])
         self.stdout.write(f"entry signals: {entry_signal_list}\n")


### PR DESCRIPTION
## Summary
- Extend strategy signal computation to capture symbols passing dollar-volume filters and their Fama–French groups
- Propagate filtered symbols through daily_job and CLI to display eligible symbols before entry/exit signals
- Add tests for filtered symbol output in history signal workflow

## Testing
- `pytest tests/test_manage.py::test_find_history_signal_prints_filtered_symbols tests/test_strategy.py::test_compute_signals_for_date_returns_filtered_symbols_with_groups -q`
- `pytest` *(fails: assert 0.20099039062670807 == 0.20099 ± 2.0e-07)*

------
https://chatgpt.com/codex/tasks/task_b_68c2df812ed0832b9d1e64e274653aa8