### PR TITLE
Add exit reasons to trades and report in simulations

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -101,10 +101,14 @@ def save_trade_details_to_log(
                     if trade_detail.percentage_change is not None:
                         result_suffix = (
                             f" {trade_detail.result} "
-                            f"{trade_detail.percentage_change:.2%}"
+                            f"{trade_detail.percentage_change:.2%} "
+                            f"{trade_detail.exit_reason}"
                         )
                     else:
-                        result_suffix = f" {trade_detail.result}"
+                        result_suffix = (
+                            f" {trade_detail.result} "
+                            f"{trade_detail.exit_reason}"
+                        )
                 else:
                     result_suffix = ""
                 open_metrics = ""
@@ -841,6 +845,7 @@ class StockShell(cmd.Cmd):
                         "exit_date": detail.date.date(),
                         "result": detail.result,
                         "percentage_change": detail.percentage_change,
+                        "exit_reason": detail.exit_reason,
                     }
                 )
         output_directory = Path("logs") / "simulate_result"
@@ -861,6 +866,7 @@ class StockShell(cmd.Cmd):
                 "exit_date",
                 "result",
                 "percentage_change",
+                "exit_reason",
             ],
         ).to_csv(output_file, index=False)
         save_trade_details_to_log(
@@ -902,10 +908,14 @@ class StockShell(cmd.Cmd):
                         if trade_detail.percentage_change is not None:
                             result_suffix = (
                                 f" {trade_detail.result} "
-                                f"{trade_detail.percentage_change:.2%}"
+                                f"{trade_detail.percentage_change:.2%} "
+                                f"{trade_detail.exit_reason}"
                             )
                         else:
-                            result_suffix = f" {trade_detail.result}"
+                            result_suffix = (
+                                f" {trade_detail.result} "
+                                f"{trade_detail.exit_reason}"
+                            )
                     else:
                         result_suffix = ""
                     open_metrics = ""
@@ -1175,11 +1185,18 @@ class StockShell(cmd.Cmd):
                     if (
                         trade_detail.action == "close"
                         and trade_detail.result is not None
-                        and trade_detail.percentage_change is not None
                     ):
-                        result_suffix = (
-                            f" {trade_detail.result} {trade_detail.percentage_change:.2%}"
-                        )
+                        if trade_detail.percentage_change is not None:
+                            result_suffix = (
+                                f" {trade_detail.result} "
+                                f"{trade_detail.percentage_change:.2%} "
+                                f"{trade_detail.exit_reason}"
+                            )
+                        else:
+                            result_suffix = (
+                                f" {trade_detail.result} "
+                                f"{trade_detail.exit_reason}"
+                            )
                     else:
                         result_suffix = ""
                     open_metrics = ""
@@ -1434,11 +1451,18 @@ class StockShell(cmd.Cmd):
                     if (
                         trade_detail.action == "close"
                         and trade_detail.result is not None
-                        and trade_detail.percentage_change is not None
                     ):
-                        result_suffix = (
-                            f" {trade_detail.result} {trade_detail.percentage_change:.2%}"
-                        )
+                        if trade_detail.percentage_change is not None:
+                            result_suffix = (
+                                f" {trade_detail.result} "
+                                f"{trade_detail.percentage_change:.2%} "
+                                f"{trade_detail.exit_reason}"
+                            )
+                        else:
+                            result_suffix = (
+                                f" {trade_detail.result} "
+                                f"{trade_detail.exit_reason}"
+                            )
                     else:
                         result_suffix = ""
                     open_metrics = ""

--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -42,6 +42,7 @@ class Trade:
     exit_price: float
     profit: float
     holding_period: int
+    exit_reason: str = "signal"
 
 
 @dataclass
@@ -160,6 +161,7 @@ def simulate_trades(
                             exit_price=exit_price,
                             profit=profit_value,
                             holding_period=holding_period_value,
+                            exit_reason="stop_loss",
                         )
                     )
                     in_position = False
@@ -188,6 +190,7 @@ def simulate_trades(
                         exit_price=exit_price,
                         profit=profit_value,
                         holding_period=holding_period_value,
+                        exit_reason="stop_loss",
                     )
                 )
                 in_position = False
@@ -250,6 +253,7 @@ def simulate_trades(
                 exit_price=exit_price,
                 profit=profit_value,
                 holding_period=holding_period_value,
+                exit_reason="end_of_data",
             )
         )
     total_profit = sum(completed_trade.profit for completed_trade in trades)

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -380,7 +380,8 @@ class TradeDetail:
     approximates the number of significant volume clusters. The ``result``
     field marks whether a closed trade ended in a win or a loss. For closing
     trades, ``percentage_change`` records the fractional price change between
-    entry and exit.
+    entry and exit. The ``exit_reason`` field captures why a trade closed,
+    such as ``"signal"``, ``"stop_loss"``, or ``"end_of_data"``.
     """
     # TODO: review
     date: pandas.Timestamp
@@ -404,6 +405,7 @@ class TradeDetail:
     concurrent_position_count: int = 0
     result: str | None = None  # TODO: review
     percentage_change: float | None = None  # TODO: review
+    exit_reason: str = "signal"
 
 
 @dataclass
@@ -2111,6 +2113,7 @@ def evaluate_combined_strategy(
                 percentage_change=percentage_change,
                 group_total_simple_moving_average_dollar_volume=group_exit_total,
                 group_simple_moving_average_dollar_volume_ratio=group_exit_ratio,
+                exit_reason=completed_trade.exit_reason,
             )
             trade_details_by_year.setdefault(
                 completed_trade.entry_date.year, []

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -633,6 +633,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
                     simple_moving_average_dollar_volume_ratio=0.3,
                     result="lose",
                     percentage_change=-1.0 / 30.0,
+                    exit_reason="end_of_data",
                 ),
             ],
         }
@@ -680,7 +681,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         in output_buffer.getvalue()
     )
     assert (
-        "  2023-01-05 AAA close 11.00 0.1000 100.00M 1000.00M win 10.00%"
+        "  2023-01-05 AAA close 11.00 0.1000 100.00M 1000.00M win 10.00% signal"
         in output_buffer.getvalue()
     )
     assert (
@@ -688,7 +689,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         in output_buffer.getvalue()
     )
     assert (
-        "  2024-03-05 CCC close 29.00 0.3000 300.00M 1000.00M lose -3.33%"
+        "  2024-03-05 CCC close 29.00 0.3000 300.00M 1000.00M lose -3.33% end_of_data"
         in output_buffer.getvalue()
     )
 
@@ -1979,6 +1980,7 @@ def test_start_simulate_creates_csv(
         "exit_date",
         "result",
         "percentage_change",
+        "exit_reason",
     ]
 
 
@@ -2050,5 +2052,5 @@ def test_start_simulate_writes_trade_detail_log(
     assert len(log_files) == 1
     assert log_files[0].read_text(encoding="utf-8").splitlines() == [
         "  2024-01-02 (1) AAA open 10.00 0.0000 0.00M 0.00M price_score=1.00 near_pct=0.50 above_pct=0.30 node_count=2",
-        "  2024-01-05 (0) AAA close 12.00 0.0000 0.00M 0.00M win 20.00%",
+        "  2024-01-05 (0) AAA close 12.00 0.0000 0.00M 0.00M win 20.00% signal",
     ]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -171,6 +171,7 @@ def test_simulate_trades_closes_open_position_at_end() -> None:
     assert final_trade.exit_date == price_data_frame.index[-1]
     assert final_trade.exit_price == 3.0
     assert final_trade.holding_period == 1
+    assert final_trade.exit_reason == "end_of_data"
 
 
 def test_simulate_trades_applies_stop_loss_next_open() -> None:


### PR DESCRIPTION
## Summary
- Track why each trade exits with a new `exit_reason` field
- Mark final positions as `end_of_data` and include reason in trade reporting
- Record exit reasons in simulation CSV output and detail logs

## Testing
- `pytest` *(fails: ModuleNotFoundError and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_b_68c2ebeabdc0832bbc4efedd37653383