### PR TITLE
Avoid warning when local history is missing

### DIFF
--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -247,11 +247,11 @@ def find_history_signal(
             if evaluation_timestamp not in history_frame.index:
                 missing_symbols.append(symbol_name)
         if missing_symbols:
-            warning_symbol_list = ", ".join(sorted(missing_symbols))
-            LOGGER.warning(
+            missing_symbol_list = ", ".join(sorted(missing_symbols))
+            LOGGER.debug(
                 "Skipping symbols missing %s: %s",
                 date_string,
-                warning_symbol_list,
+                missing_symbol_list,
             )
             local_symbols = [
                 symbol_name


### PR DESCRIPTION
## Summary
- Log missing-symbol cases at debug level so daily job runs do not emit warnings for absent historical data

## Testing
- `pytest -q` *(fails: requests.exceptions.ProxyError: HTTPSConnectionPool(host='www.sec.gov', port=443): Max retries exceeded with url: /files/company_tickers.json (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_b_68c3121133fc832b829906f9adeeb5ea