### PR TITLE
Ensure filtered symbol line prints even when empty

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -1612,8 +1612,7 @@ class StockShell(cmd.Cmd):
         filtered_symbol_list: List[tuple[str, int | None]] = signal_data.get(
             "filtered_symbols", []
         )
-        if filtered_symbol_list:
-            self.stdout.write(f"filtered symbols: {filtered_symbol_list}\n")
+        self.stdout.write(f"filtered symbols: {filtered_symbol_list}\n")
         entry_signal_list: List[str] = signal_data.get("entry_signals", [])
         exit_signal_list: List[str] = signal_data.get("exit_signals", [])
         self.stdout.write(f"entry signals: {entry_signal_list}\n")

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -411,6 +411,43 @@ def test_find_history_signal_prints_filtered_symbols(monkeypatch: pytest.MonkeyP
     ]
 
 
+def test_find_history_signal_prints_empty_filtered_symbols(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command should include the filtered symbols line when no symbols remain."""
+    import stock_indicator.manage as manage_module
+
+    def fake_find_history_signal(
+        date_string: str,
+        dollar_volume_filter: str,
+        buy_strategy: str,
+        sell_strategy: str,
+        stop_loss: float,
+        allowed_group_identifiers: set[int] | None = None,
+    ) -> dict[str, list[object]]:
+        return {
+            "filtered_symbols": [],
+            "entry_signals": [],
+            "exit_signals": [],
+        }
+
+    monkeypatch.setattr(
+        manage_module.daily_job, "find_history_signal", fake_find_history_signal
+    )
+
+    output_buffer = io.StringIO()
+    shell = manage_module.StockShell(stdout=output_buffer)
+    shell.onecmd(
+        "find_history_signal 2024-01-10 dollar_volume>1 ema_sma_cross ema_sma_cross 1.0",
+    )
+
+    assert output_buffer.getvalue().splitlines() == [
+        "filtered symbols: []",
+        "entry signals: []",
+        "exit signals: []",
+    ]
+
+
 # TODO: review
 def test_filter_debug_values_prints_table(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Always display the `filtered symbols` line in `do_find_history_signal`
- Test that the command prints the empty filtered-symbols line

## Testing
- `pytest tests/test_manage.py::test_find_history_signal_prints_filtered_symbols tests/test_manage.py::test_find_history_signal_prints_empty_filtered_symbols -q`
- `pytest -q` *(fails: 41 failed, 137 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68c31339820c832bbf5bf0320522ccb5