### PR TITLE
Use signal-day chip metrics for trade details

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -2087,8 +2087,22 @@ def evaluate_combined_strategy(
                 group_entry_ratio = float(entry_volume_ratio)
             else:
                 group_entry_ratio = float(entry_dollar_volume) / group_entry_total
+            try:
+                entry_index_position = price_data_frame.index.get_loc(
+                    completed_trade.entry_date
+                )
+            except KeyError:
+                signal_date = completed_trade.entry_date
+            else:
+                if (
+                    isinstance(entry_index_position, int)
+                    and entry_index_position > 0
+                ):
+                    signal_date = price_data_frame.index[entry_index_position - 1]
+                else:
+                    signal_date = completed_trade.entry_date
             chip_metrics = calculate_chip_concentration_metrics(
-                price_data_frame.loc[: completed_trade.entry_date],
+                price_data_frame.loc[: signal_date],
                 lookback_window_size=60,
                 include_volume_profile=False,
             )  # TODO: review


### PR DESCRIPTION
## Summary
- Determine signal day before trade entry and recompute chip concentration metrics using data up to that day
- Record prior-day chip metrics in TradeDetail entries
- Test TradeDetail chip metrics across non-trading gaps

## Testing
- `pytest tests/test_strategy.py::test_evaluate_combined_strategy_trade_details_use_signal_day_chip_metrics tests/test_strategy.py::test_evaluate_combined_strategy_trade_details_use_latest_average_dollar_volume tests/test_strategy.py::test_attach_ema_sma_cross_testing_uses_previous_day_ratios_on_gap -q`


------
https://chatgpt.com/codex/tasks/task_b_68c37f991548832b9f1242015ffaa515