### PR TITLE
feat: support strategy range parameters

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -161,17 +161,17 @@ start_simulate dollar_volume>1 ema_sma_cross_with_slope_40_-5.7_50.2 ema_sma_cro
 The testing variant `ema_sma_cross_testing` accepts the same optional window
 size and slope range suffixes. In addition to the EMA/SMA cross and slope
 filters, it recalculates chip concentration metrics. Strategy names follow
-`ema_sma_cross_testing_<window>_<lower>_<upper>_<near>_<above>`:
+`ema_sma_cross_testing_<window>_<lower>_<upper>_<near_min>,<near_max>_<above_min>,<above_max>`:
 
 * `<window>` — EMA and SMA window size (default `40`).
 * `<lower>` and `<upper>` — inclusive simple moving average angle bounds in degrees (defaults `-16.7` and `65`).
-* `<near>` — maximum allowed near-price volume ratio (default `0.12`).
-* `<above>` — maximum allowed above-price volume ratio (default `0.10`).
+* `<near_min>` and `<near_max>` — inclusive bounds for the near-price volume ratio (default `0.0`–`0.12`).
+* `<above_min>` and `<above_max>` — inclusive bounds for the above-price volume ratio (default `0.0`–`0.10`).
 
-Example with custom chip concentration thresholds:
+Example with custom chip concentration ranges:
 
 ```
-start_simulate dollar_volume>1 ema_sma_cross_testing_40_-16.7_65_0.2_0.15 ema_sma_cross_testing_40_-16.7_65_0.2_0.15
+start_simulate dollar_volume>1 ema_sma_cross_testing_40_-16.7_65_0.1,0.2_0.05,0.15 ema_sma_cross_testing_40_-16.7_65_0.1,0.2_0.05,0.15
 ```
 
 The tests `tests/test_manage.py::test_start_simulate_accepts_slope_range_strategy_names` and `tests/test_strategy.py::test_evaluate_combined_strategy_passes_slope_range` confirm this behavior. The management test shows the command accepts strategy names with slope bounds, and the strategy test verifies that the evaluation routine passes the bounds to the strategy implementation.

--- a/README.md
+++ b/README.md
@@ -185,17 +185,19 @@ For experimentation, the `ema_sma_cross_testing` strategy offers the same
 optional window size and slope range suffixes. It omits the long-term simple
 moving average requirement and additionally filters signals using chip
 concentration metrics. Strategy names follow the pattern
-`ema_sma_cross_testing_<window>_<lower>_<upper>_<near>_<above>`, where:
+`ema_sma_cross_testing_<window>_<lower>_<upper>_<near_min>,<near_max>_<above_min>,<above_max>`, where:
 
 * `<window>` — EMA and SMA window size (default `40`).
 * `<lower>` and `<upper>` — inclusive bounds for the simple moving average angle in degrees (defaults `-16.7` and `65`).
-* `<near>` — maximum fraction of volume near the current price (default `0.12`).
-* `<above>` — maximum fraction of volume above the current price (default `0.10`).
+* `<near_min>` and `<near_max>` — inclusive bounds for the fraction of volume near the current price (default `0.0`–`0.12`).
+* `<above_min>` and `<above_max>` — inclusive bounds for the fraction of volume above the current price (default `0.0`–`0.10`).
 
-Example with custom chip concentration thresholds:
+Example with custom chip concentration ranges:
 
 ```bash
-(stock-indicator) start_simulate dollar_volume>1 ema_sma_cross_testing_40_-16.7_65_0.2_0.15 ema_sma_cross_testing_40_-16.7_65_0.2_0.15
+(stock-indicator) start_simulate dollar_volume>1 \
+  ema_sma_cross_testing_40_-16.7_65_0.1,0.2_0.05,0.15 \
+  ema_sma_cross_testing_40_-16.7_65_0.1,0.2_0.05,0.15
 ```
 
 When omitted, the window size defaults to 40 days.

--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -331,8 +331,8 @@ def filter_debug_values(
         buy_base_name,
         buy_window_size,
         buy_angle_range,
-        buy_near_percentage,
-        buy_above_percentage,
+        buy_near_range,
+        buy_above_range,
     ) = strategy.parse_strategy_name(buy_strategy_name)
     buy_function = strategy.BUY_STRATEGIES.get(buy_base_name)
     if buy_function is not None:
@@ -341,18 +341,18 @@ def filter_debug_values(
             buy_arguments["window_size"] = buy_window_size
         if buy_angle_range is not None:
             buy_arguments["angle_range"] = buy_angle_range
-        if buy_near_percentage is not None:
-            buy_arguments["near_pct"] = buy_near_percentage
-        if buy_above_percentage is not None:
-            buy_arguments["above_pct"] = buy_above_percentage
+        if buy_near_range is not None:
+            buy_arguments["near_range"] = buy_near_range
+        if buy_above_range is not None:
+            buy_arguments["above_range"] = buy_above_range
         buy_function(buy_price_history_frame, **buy_arguments)
 
     (
         sell_base_name,
         sell_window_size,
         sell_angle_range,
-        sell_near_percentage,
-        sell_above_percentage,
+        sell_near_range,
+        sell_above_range,
     ) = strategy.parse_strategy_name(sell_strategy_name)
     sell_function = strategy.SELL_STRATEGIES.get(sell_base_name)
     if sell_function is not None:
@@ -361,10 +361,10 @@ def filter_debug_values(
             sell_arguments["window_size"] = sell_window_size
         if sell_angle_range is not None:
             sell_arguments["angle_range"] = sell_angle_range
-        if sell_near_percentage is not None:
-            sell_arguments["near_pct"] = sell_near_percentage
-        if sell_above_percentage is not None:
-            sell_arguments["above_pct"] = sell_above_percentage
+        if sell_near_range is not None:
+            sell_arguments["near_range"] = sell_near_range
+        if sell_above_range is not None:
+            sell_arguments["above_range"] = sell_above_range
         sell_function(sell_price_history_frame, **sell_arguments)
 
     # TODO: review

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -2081,7 +2081,9 @@ def test_start_simulate_writes_trade_detail_log(
 
     shell = manage_module.StockShell(stdout=io.StringIO())
     shell.onecmd(
-        "start_simulate start=2024-01-01 dollar_volume>1 ema_sma_cross ema_sma_cross 1 false"
+        "start_simulate start=2024-01-01 dollar_volume>1 "
+        "ema_sma_cross_testing_40_-16.7_65_0.0,1.0_0.0,1.0 "
+        "ema_sma_cross_testing_40_-16.7_65_0.0,1.0_0.0,1.0 1 false"
     )
 
     log_directory = tmp_path / "logs" / "trade_detail"


### PR DESCRIPTION
## Summary
- parse strategy names into near and above ranges instead of single thresholds
- propagate range tuples through daily jobs and strategy evaluation
- allow `ema_sma_cross_testing` to filter by inclusive chip ratio ranges

## Testing
- `pytest` *(fails: Unsupported strategy and ImportError across suite)*


------
https://chatgpt.com/codex/tasks/task_b_68c38d7dcd30832b96957ddc3fd5327a