### PR TITLE
Handle strategy identifiers with comma-separated ranges

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -39,12 +39,13 @@ STOCK_DATA_DIRECTORY = DATA_DIRECTORY / "stock_data"
 def _resolve_strategy_choice(raw_name: str, allowed: dict) -> str:
     """Return the first supported strategy token from ``raw_name``.
 
-    Allows config values like "ema_a | ema_b" or "ema_a or ema_b"; picks the
-    first token whose base name exists in the provided ``allowed`` dict.
-    Falls back to the original name when none match.
+    Configuration values may contain simple logical expressions such as
+    ``"ema_a | ema_b"`` or ``"ema_a or ema_b"``. The function splits the
+    expression on the recognized separators and returns the first token whose
+    base name exists in the ``allowed`` dictionary. If none match, the original
+    ``raw_name`` is returned unchanged.
     """
-    # Split on common separators: "or", "|", ",", "/"
-    parts = re.split(r"\s*(?:\bor\b|\||,|/)\s*", raw_name.strip())
+    parts = re.split(r"\s*(?:\bor\b|\||/)\s*", raw_name.strip())
     for token in parts:
         if not token:
             continue
@@ -63,8 +64,8 @@ def _has_supported_strategy(expression: str, allowed: dict) -> bool:
     The function first attempts to parse ``expression`` as a single strategy
     name. When that succeeds and the resulting base name is found in
     ``allowed``, the strategy is considered supported. Only if parsing the
-    entire expression fails do we split on common separators (``or``, ``|``,
-    ``/``, ``,``) and check each token individually.
+    entire expression fails do we split on the recognized separators (``or``,
+    ``|``, ``/``) and check each token individually.
     """
     try:
         base_name, _, _, _, _ = strategy.parse_strategy_name(expression)
@@ -77,7 +78,7 @@ def _has_supported_strategy(expression: str, allowed: dict) -> bool:
             if expression.startswith(f"{allowed_name}_"):
                 return True
 
-    parts = re.split(r"\s*(?:\bor\b|\||/|,)\s*", expression.strip())
+    parts = re.split(r"\s*(?:\bor\b|\||/)\s*", expression.strip())
     for token in parts:
         if not token:
             continue

--- a/tests/test_split_strategy_choices.py
+++ b/tests/test_split_strategy_choices.py
@@ -1,0 +1,22 @@
+"""Tests for strategy choice splitting utility."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+import stock_indicator.strategy as strategy
+
+
+def test_split_strategy_choices_preserves_internal_commas() -> None:
+    """Ensure commas used for numeric parameters are not treated as separators."""
+    complex_name = "ema_sma_cross_testing_4_-0.01_65_0.05,0.0802_0.83,1.00"
+    tokens = strategy._split_strategy_choices(complex_name)
+    assert tokens == [complex_name]
+
+
+def test_split_strategy_choices_splits_on_or_token() -> None:
+    """Verify that recognized separators split strategy expressions."""
+    composite_name = "first or second"
+    tokens = strategy._split_strategy_choices(composite_name)
+    assert tokens == ["first", "second"]


### PR DESCRIPTION
## Summary
- avoid splitting strategy names on commas to keep numeric ranges intact
- improve strategy name parser to recognize comma-delimited ranges
- adjust strategy helpers and add unit tests for splitting logic

## Testing
- `pytest`
- `pytest tests/test_split_strategy_choices.py -q`
- `pytest tests/test_strategy.py::test_parse_strategy_name_with_near_and_above_thresholds -q`


------
https://chatgpt.com/codex/tasks/task_b_68c39ccc25c4832b9234b413df744b94