### PR TITLE
Run find_history_signal with multiple argument sets

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -28,7 +28,12 @@ START_DATE="$(date -d "$LATEST_DATE -1 year" +%F)"
 
 # Update historical data and record signals
 "$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage update_all_data_from_yf "$START_DATE" "$LATEST_DATE" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
+
+echo 'ARG_LINE_1' >> "$LOG_DIRECTORY/cron_stdout.log"
 "$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage find_history_signal "$LATEST_DATE" "$ARG_LINE_1" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
+
+echo 'ARG_LINE_2' >> "$LOG_DIRECTORY/cron_stdout.log"
+"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage find_history_signal "$LATEST_DATE" "$ARG_LINE_2" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
 
 # Write a marker file for the latest run
 # TODO: review


### PR DESCRIPTION
## Summary
- Update `run_daily_job.sh` to invoke `find_history_signal` twice using `ARG_LINE_1` and `ARG_LINE_2`
- Append each invocation's results to the shared cron log for easier comparison

## Testing
- `pytest -q` *(fails: requests.exceptions.ProxyError and multiple assertion errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c40d0da8b4832bb980027e0d61d5c6