### PR TITLE
Use Python to compute start date in daily job

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -24,7 +24,7 @@ cd "$SOURCE_DIRECTORY"
 
 # TODO: review - compute the latest trading date and one-year start date
 LATEST_DATE="$("$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -c 'from stock_indicator.daily_job import determine_latest_trading_date as determine_date;print(determine_date())')"
-START_DATE="$(date -d "$LATEST_DATE -1 year" +%F)"
+START_DATE="$("$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -c 'from datetime import datetime, timedelta; import sys; print((datetime.fromisoformat(sys.argv[1]) - timedelta(days=365)).date().isoformat())' "$LATEST_DATE")"
 
 # Update historical data and record signals
 "$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage update_all_data_from_yf "$START_DATE" "$LATEST_DATE" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1


### PR DESCRIPTION
## Summary
- Replace GNU date command with cross-platform Python calculation for start date in `run_daily_job.sh`

## Testing
- `bash -n run_daily_job.sh`
- `VENV=/root/.pyenv/versions/3.12.10 timeout 5 bash -x run_daily_job.sh` *(fails: terminated by timeout)*
- `pytest` *(fails: assert 0.20099039062670807 == 0.20099 ± 2.0e-07)*

------
https://chatgpt.com/codex/tasks/task_b_68c490d89f20832ba30b8ec7c6fe65d1