### PR TITLE
Log find_history_signal outputs to daily log

### DIFF
--- a/run_daily_job.sh
+++ b/run_daily_job.sh
@@ -29,12 +29,14 @@ START_DATE="$("$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -c 'from datetime impo
 # Update historical data and record signals
 "$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage update_all_data_from_yf "$START_DATE" "$LATEST_DATE" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
 
-echo "$ARG_LINE_1" >> "$LOG_DIRECTORY/cron_stdout.log" # TODO: review
-"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage find_history_signal "$LATEST_DATE" "$ARG_LINE_1" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
-
-echo "$ARG_LINE_2" >> "$LOG_DIRECTORY/cron_stdout.log" # TODO: review
-"$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage find_history_signal "$LATEST_DATE" "$ARG_LINE_2" >> "$LOG_DIRECTORY/cron_stdout.log" 2>&1
-
-# Write a marker file for the latest run
 # TODO: review
-: > "$DATE_LOG_DIRECTORY/$LATEST_DATE.log"
+{
+  echo "$ARG_LINE_1"
+  "$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage find_history_signal "$LATEST_DATE" "$ARG_LINE_1"
+} | tee -a "$LOG_DIRECTORY/cron_stdout.log" >> "$DATE_LOG_DIRECTORY/$LATEST_DATE.log"
+
+# TODO: review
+{
+  echo "$ARG_LINE_2"
+  "$VIRTUAL_ENVIRONMENT_DIRECTORY/bin/python" -m stock_indicator.manage find_history_signal "$LATEST_DATE" "$ARG_LINE_2"
+} | tee -a "$LOG_DIRECTORY/cron_stdout.log" >> "$DATE_LOG_DIRECTORY/$LATEST_DATE.log"


### PR DESCRIPTION
## Summary
- Stream find_history_signal runs through tee to both cron log and dated log files
- Drop explicit marker file creation; the tee pipeline now generates daily logs

## Testing
- `pytest` *(fails: ProxyError and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_b_68c4a4264da0832bbb33b9ef321c17e4