### PR TITLE
Include pending credits in annual return calculations

### DIFF
--- a/src/stock_indicator/simulator.py
+++ b/src/stock_indicator/simulator.py
@@ -681,8 +681,9 @@ def calculate_annual_returns(
         next_date = current_date + pandas.Timedelta(days=1)
         next_year = next_date.year
         if next_year != current_year or current_date == end_date:
-            # compute end-of-year portfolio value MTM
-            portfolio_value = cash_balance + sum(
+            unsettled_proceeds_value = sum(pending_credits.values())
+            # Mark unsettled exit proceeds to market by including pending credits.
+            portfolio_value = cash_balance + unsettled_proceeds_value + sum(
                 pos.share_count * (pos.last_known_price or 0.0)
                 for pos in open_trades.values()
             )
@@ -692,7 +693,8 @@ def calculate_annual_returns(
                 annual_returns[current_year] = (portfolio_value - year_start_value) / year_start_value
             # Apply withdrawal at year end
             cash_balance -= withdraw_amount
-            year_start_value = cash_balance + sum(
+            # Carry the mark-to-market unsettled proceeds into the new year baseline.
+            year_start_value = cash_balance + unsettled_proceeds_value + sum(
                 pos.share_count * (pos.last_known_price or 0.0)
                 for pos in open_trades.values()
             )


### PR DESCRIPTION
## Summary
- include pending settlement credits when marking year-end portfolio value and next-year starting equity in `calculate_annual_returns`
- document the mark-to-market treatment and carry the same unsettled proceeds into the new year baseline
- add a regression test that ensures T+1 settlements exiting on December 31 boost the prior year's return

## Testing
- pytest tests/test_simulator.py::test_calculate_annual_returns_marks_unsettled_proceeds_in_year_end -q

------
https://chatgpt.com/codex/tasks/task_b_68c92447f3c0832b802e81868ac455a4