### PR TITLE
Adjust complex simulation capacity rounding

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -821,7 +821,7 @@ class StockShell(cmd.Cmd):
             "[start=YYYY-MM-DD] [margin=NUMBER] SET_A -- SET_B [SHOW_DETAILS]\n"
             "Evaluate two strategy sets using a shared cash balance.\n"
             "Parameters:\n"
-            "  MAX_POSITION_COUNT: Maximum concurrent positions for set A. Set B receives half (rounded down, minimum one).\n"
+            "  MAX_POSITION_COUNT: Maximum concurrent positions for set A. Set B receives half (rounded up, minimum one).\n"
             "  starting_cash: Optional initial cash balance. Defaults to 3000.\n"
             "  withdraw: Optional annual withdrawal amount. Defaults to 0.\n"
             "  start: Optional start date in YYYY-MM-DD format. Defaults to earliest cached data.\n"

--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -481,7 +481,9 @@ def run_complex_simulation(
     for label, definition in set_definitions.items():
         maximum_positions_for_set = maximum_position_count
         if label.upper() == "B":
-            maximum_positions_for_set = max(1, maximum_position_count // 2)
+            maximum_positions_for_set = max(
+                1, math.ceil(maximum_position_count / 2)
+            )
         metrics = evaluate_combined_strategy(
             data_directory,
             definition.buy_strategy_name,

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -2226,10 +2226,10 @@ def test_complex_simulation_strategy_id_resolution(
     assert "[B] Trades: 0" in output_text
 
 
-def test_complex_simulation_half_cap_for_set_b(
+def test_complex_simulation_half_cap_for_set_b_rounds_up(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Set B should receive half of the maximum position count."""
+    """Set B should receive half of the maximum position count, rounded up."""
 
     import stock_indicator.manage as manage_module
 
@@ -2258,9 +2258,9 @@ def test_complex_simulation_half_cap_for_set_b(
     output_buffer = io.StringIO()
     shell = manage_module.StockShell(stdout=output_buffer)
     shell.onecmd(
-        "complex_simulation 6 dollar_volume>1 ema_sma_cross ema_sma_cross -- "
+        "complex_simulation 5 dollar_volume>1 ema_sma_cross ema_sma_cross -- "
         "dollar_volume>1 ema_sma_cross_20 ema_sma_cross_20"
     )
 
-    assert recorded_maximums["ema_sma_cross"] == 6
+    assert recorded_maximums["ema_sma_cross"] == 5
     assert recorded_maximums["ema_sma_cross_20"] == 3


### PR DESCRIPTION
## Summary
- apply a rounded-up half-capacity rule to set B in complex simulations
- document the rounding behavior in the complex_simulation CLI help text
- extend the complex simulation test to cover odd maximum position counts

## Testing
- pytest tests/test_manage.py::test_complex_simulation_half_cap_for_set_b_rounds_up

------
https://chatgpt.com/codex/tasks/task_b_68d111b4bdc8832b88c68032c82f5d13