### PR TITLE
Clarify complex_simulation usage

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -526,11 +526,15 @@ class StockShell(cmd.Cmd):
         """complex_simulation MAX_POSITION_COUNT [starting_cash=NUMBER] [withdraw=NUMBER] [start=YYYY-MM-DD] [margin=NUMBER] SET_A -- SET_B [SHOW_DETAILS]
         Evaluate two strategy sets with shared capital limits."""
 
+        usage_message = (
+            "usage: complex_simulation MAX_POSITION_COUNT [starting_cash=NUMBER] "
+            "[withdraw=NUMBER] [start=YYYY-MM-DD] [margin=NUMBER] SET_A -- SET_B "
+            "[SHOW_DETAILS]\n"
+        )
+
         argument_parts: List[str] = argument_line.split()
         if not argument_parts:
-            self.stdout.write(
-                "usage: complex_simulation MAX_POSITION_COUNT -- SET_A -- SET_B\n"
-            )
+            self.stdout.write(usage_message)
             return
 
         maximum_position_token = argument_parts.pop(0)
@@ -596,18 +600,14 @@ class StockShell(cmd.Cmd):
         for token in argument_parts:
             if token == "--":
                 if not set_tokens[-1]:
-                    self.stdout.write(
-                        "usage: complex_simulation MAX_POSITION_COUNT -- SET_A -- SET_B\n"
-                    )
+                    self.stdout.write(usage_message)
                     return
                 set_tokens.append([])
                 continue
             set_tokens[-1].append(token)
 
         if len(set_tokens) != 2 or any(not tokens for tokens in set_tokens):
-            self.stdout.write(
-                "usage: complex_simulation MAX_POSITION_COUNT -- SET_A -- SET_B\n"
-            )
+            self.stdout.write(usage_message)
             return
 
         strategy_mapping = load_strategy_set_mapping()

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -2171,7 +2171,11 @@ def test_complex_simulation_requires_two_sets(
     shell.onecmd("complex_simulation 3")
     assert (
         output_buffer.getvalue()
-        == "usage: complex_simulation MAX_POSITION_COUNT -- SET_A -- SET_B\n"
+        == (
+            "usage: complex_simulation MAX_POSITION_COUNT [starting_cash=NUMBER] "
+            "[withdraw=NUMBER] [start=YYYY-MM-DD] [margin=NUMBER] SET_A -- SET_B "
+            "[SHOW_DETAILS]\n"
+        )
     )
 
 


### PR DESCRIPTION
## Summary
- expand the complex_simulation usage guidance to list all optional parameters
- reuse the updated usage message whenever argument validation fails
- adjust the complex_simulation usage test to expect the new guidance

## Testing
- pytest tests/test_manage.py::test_complex_simulation_requires_two_sets

------
https://chatgpt.com/codex/tasks/task_b_68d12de8606c832b81a3f40942fc1d0a