### PR TITLE
Add strategy-aware priority ordering for complex simulation

### DIFF
--- a/src/stock_indicator/manage.py
+++ b/src/stock_indicator/manage.py
@@ -683,6 +683,7 @@ class StockShell(cmd.Cmd):
                 label=label,
                 buy_strategy_name=buy_strategy_name,
                 sell_strategy_name=sell_strategy_name,
+                strategy_identifier=strategy_identifier,
                 stop_loss_percentage=stop_loss_percentage,
                 minimum_average_dollar_volume=minimum_average_dollar_volume,
                 minimum_average_dollar_volume_ratio=


### PR DESCRIPTION
## Summary
- add an optional strategy identifier to complex strategy set definitions and populate it via the CLI builder
- derive per-set entry priorities for s4 and s6 simulations so the correct trade wins shared-capacity slots
- extend the test trade builder and add regression tests that cover the new priority behavior

## Testing
- pytest tests/test_strategy_complex.py

------
https://chatgpt.com/codex/tasks/task_b_68d267d7657c832bb009f1aefef9ce07