### PR TITLE
Adjust s4 priority to favor lower above-ratio trades

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -589,7 +589,7 @@ def run_complex_simulation(
                         if entry_detail.above_price_volume_ratio is not None
                         else float("inf")
                     )
-                    entry_priority = -ratio_value
+                    entry_priority = ratio_value
                 elif priority_mode == "s6":
                     ratio_value = (
                         entry_detail.near_price_volume_ratio

--- a/tests/test_strategy_complex.py
+++ b/tests/test_strategy_complex.py
@@ -326,10 +326,10 @@ def test_run_complex_simulation_overall_metrics_use_global_limits(
     assert call_records["calculate_max_drawdown"][-1] == 3
 
 
-def test_run_complex_simulation_prioritizes_high_above_ratio_for_s4(
+def test_run_complex_simulation_prioritizes_low_above_ratio_for_s4(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Set definitions linked to s4 favor higher above-ratio entries."""
+    """Set definitions linked to s4 favor lower above-ratio entries."""
 
     lower_ratio_trade = _build_trade(
         "2024-01-01",
@@ -376,7 +376,7 @@ def test_run_complex_simulation_prioritizes_high_above_ratio_for_s4(
         if detail.action == "open"
     ]
     assert len(entry_details) == 1
-    assert entry_details[0].symbol == "HIGH"
+    assert entry_details[0].symbol == "LOW"
 
 
 def test_run_complex_simulation_prioritizes_low_near_ratio_for_s6(


### PR DESCRIPTION
## Summary
- update the complex simulation priority logic so s4 favors entries with lower above-price volume ratios
- adjust the regression test to reflect the new s4 behavior when selecting trades

## Testing
- pytest tests/test_strategy_complex.py

------
https://chatgpt.com/codex/tasks/task_b_68d2d9350050832bbfc5884987a1fbb9