### PR TITLE
Support take-profit configuration for complex simulations

### DIFF
--- a/src/stock_indicator/strategy.py
+++ b/src/stock_indicator/strategy.py
@@ -423,7 +423,7 @@ class TradeDetail:
     marks whether a closed trade ended in a win or a loss. For closing trades,
     ``percentage_change`` records the fractional price change between entry and
     exit. The ``exit_reason`` field captures why a trade closed, such as
-    ``"signal"``, ``"stop_loss"``, or ``"end_of_data"``.
+    ``"signal"``, ``"stop_loss"``, ``"take_profit"``, or ``"end_of_data"``.
     """
     # TODO: review
     date: pandas.Timestamp
@@ -483,6 +483,7 @@ class ComplexStrategySetDefinition:
     sell_strategy_name: str
     strategy_identifier: str | None = None
     stop_loss_percentage: float = 1.0
+    take_profit_percentage: float = 0.0
     minimum_average_dollar_volume: float | None = None
     minimum_average_dollar_volume_ratio: float | None = None
     top_dollar_volume_rank: int | None = None
@@ -562,6 +563,7 @@ def run_complex_simulation(
             allowed_symbols=None,
             exclude_other_ff12=True,
             stop_loss_percentage=definition.stop_loss_percentage,
+            take_profit_percentage=definition.take_profit_percentage,
             margin_multiplier=margin_multiplier,
             margin_interest_annual_rate=effective_interest_rate,
         )
@@ -2140,6 +2142,7 @@ def _generate_strategy_evaluation_artifacts(
     allowed_symbols: set[str] | None = None,
     exclude_other_ff12: bool = True,
     stop_loss_percentage: float = 1.0,
+    take_profit_percentage: float = 0.0,
     margin_multiplier: float = 1.0,
     margin_interest_annual_rate: float = 0.048,
 ) -> StrategyEvaluationArtifacts:
@@ -2446,6 +2449,7 @@ def _generate_strategy_evaluation_artifacts(
             entry_price_column="open",
             exit_price_column="open",
             stop_loss_percentage=stop_loss_percentage,
+            take_profit_percentage=take_profit_percentage,
             cooldown_bars=cooldown_after_close,
         )
         simulation_results.append(simulation_result)
@@ -2619,6 +2623,7 @@ def evaluate_combined_strategy(
     starting_cash: float = 3000.0,
     withdraw_amount: float = 0.0,
     stop_loss_percentage: float = 1.0,
+    take_profit_percentage: float = 0.0,
     start_date: pandas.Timestamp | None = None,
     maximum_position_count: int = 3,
     allowed_fama_french_groups: set[int] | None = None,
@@ -2643,6 +2648,7 @@ def evaluate_combined_strategy(
         allowed_symbols=allowed_symbols,
         exclude_other_ff12=exclude_other_ff12,
         stop_loss_percentage=stop_loss_percentage,
+        take_profit_percentage=take_profit_percentage,
         margin_multiplier=margin_multiplier,
         margin_interest_annual_rate=margin_interest_annual_rate,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,9 +59,11 @@ def test_run_cli_invokes_components(
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
         price_column: str = "close",
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
     ) -> SimulationResult:
         assert price_column == "close"
         assert stop_loss_percentage == 1.0
+        assert take_profit_percentage == 0.0
         return SimulationResult(trades=[], total_profit=5.0)
 
     monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)
@@ -111,11 +113,13 @@ def test_run_cli_uses_close_by_default(
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
         price_column: str = "close",
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
     ) -> SimulationResult:
         assert price_column == "close"
         assert entry_rule(data_frame.iloc[0])
         assert not exit_rule(data_frame.iloc[0], data_frame.iloc[0])
         assert stop_loss_percentage == 1.0
+        assert take_profit_percentage == 0.0
         return SimulationResult(trades=[], total_profit=0.0)
 
     monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)
@@ -165,11 +169,13 @@ def test_run_cli_accepts_price_column_argument(
         exit_rule: Callable[[pandas.Series, pandas.Series], bool],
         price_column: str = "close",
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
     ) -> SimulationResult:
         assert price_column == "open"
         assert not entry_rule(data_frame.iloc[0])
         assert exit_rule(data_frame.iloc[0], data_frame.iloc[0])
         assert stop_loss_percentage == 1.0
+        assert take_profit_percentage == 0.0
         return SimulationResult(trades=[], total_profit=0.0)
 
     monkeypatch.setattr(cli.symbols, "load_symbols", fake_load_symbols)

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -640,6 +640,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     call_record: dict[str, tuple[str, str]] = {}
     volume_record: dict[str, float] = {}
     stop_loss_record: dict[str, float] = {}
+    take_profit_record: dict[str, float] = {}
 
     from stock_indicator.strategy import StrategyMetrics, TradeDetail
 
@@ -653,6 +654,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
             starting_cash: float = 3000.0,
             withdraw_amount: float = 0.0,
             stop_loss_percentage: float = 1.0,
+            take_profit_percentage: float = 0.0,
             start_date: pandas.Timestamp | None = None,
             allowed_fama_french_groups: set[int] | None = None,
         ) -> StrategyMetrics:
@@ -661,6 +663,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
         if minimum_average_dollar_volume_ratio is not None:
             volume_record["ratio"] = minimum_average_dollar_volume_ratio
         stop_loss_record["value"] = stop_loss_percentage
+        take_profit_record["value"] = take_profit_percentage
         assert starting_cash == 3000.0
         assert withdraw_amount == 0.0
         assert data_directory in (
@@ -764,6 +767,7 @@ def test_start_simulate(monkeypatch: pytest.MonkeyPatch) -> None:
     assert call_record["strategies"] == ("ema_sma_cross", "ema_sma_cross")
     assert volume_record["threshold"] == 500.0
     assert stop_loss_record["value"] == 1.0
+    assert take_profit_record["value"] == 0.0
     assert "Simulation start date: 2019-01-01" in output_buffer.getvalue()
     summary_fragments = [
         "Trades: 3, Win rate: 66.67%",
@@ -807,6 +811,7 @@ def test_start_simulate_suppresses_trade_details(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **_: object,
     ) -> StrategyMetrics:
@@ -887,6 +892,7 @@ def test_start_simulate_filters_early_googl_trades(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         allowed_fama_french_groups: set[int] | None = None,
     ) -> StrategyMetrics:
@@ -990,6 +996,7 @@ def test_start_simulate_different_strategies(monkeypatch: pytest.MonkeyPatch) ->
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         allowed_fama_french_groups: set[int] | None = None,
     ) -> StrategyMetrics:
@@ -1051,6 +1058,7 @@ def test_start_simulate_accepts_start_date(monkeypatch: pytest.MonkeyPatch) -> N
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         allowed_fama_french_groups: set[int] | None = None,
     ) -> StrategyMetrics:
@@ -1105,6 +1113,7 @@ def test_start_simulate_dollar_volume_rank(monkeypatch: pytest.MonkeyPatch) -> N
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1157,6 +1166,7 @@ def test_start_simulate_dollar_volume_ratio(monkeypatch: pytest.MonkeyPatch) -> 
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1209,6 +1219,7 @@ def test_start_simulate_dollar_volume_threshold_and_rank(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1267,6 +1278,7 @@ def test_start_simulate_supports_rsi_strategy(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1329,6 +1341,7 @@ def test_start_simulate_supports_slope_strategy(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1391,6 +1404,7 @@ def test_start_simulate_supports_slope_and_volume_strategy(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1453,6 +1467,7 @@ def test_start_simulate_accepts_angle_range_strategy_names(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1707,6 +1722,7 @@ def test_start_simulate_supports_20_50_sma_cross_strategy(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1766,6 +1782,7 @@ def test_start_simulate_accepts_stop_loss_argument(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1802,6 +1819,65 @@ def test_start_simulate_accepts_stop_loss_argument(
     assert stop_loss_record["value"] == 0.5
 
 
+def test_start_simulate_accepts_take_profit_argument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command should forward the take profit argument to evaluation."""
+
+    import stock_indicator.manage as manage_module
+
+    stop_loss_record: dict[str, float] = {}
+    take_profit_record: dict[str, float] = {}
+
+    from stock_indicator.strategy import StrategyMetrics
+
+    def fake_evaluate(
+        data_directory: Path,
+        buy_strategy_name: str,
+        sell_strategy_name: str,
+        minimum_average_dollar_volume: float | None,
+        top_dollar_volume_rank: int | None = None,
+        minimum_average_dollar_volume_ratio: float | None = None,
+        starting_cash: float = 3000.0,
+        withdraw_amount: float = 0.0,
+        stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
+        start_date: pandas.Timestamp | None = None,
+        **kwargs: object,
+    ) -> StrategyMetrics:
+        stop_loss_record["value"] = stop_loss_percentage
+        take_profit_record["value"] = take_profit_percentage
+        return StrategyMetrics(
+            total_trades=0,
+            win_rate=0.0,
+            mean_profit_percentage=0.0,
+            profit_percentage_standard_deviation=0.0,
+            mean_loss_percentage=0.0,
+            loss_percentage_standard_deviation=0.0,
+            mean_holding_period=0.0,
+            holding_period_standard_deviation=0.0,
+            maximum_concurrent_positions=0,
+            maximum_drawdown=0.0,
+            final_balance=0.0,
+            compound_annual_growth_rate=0.0,
+            annual_returns={},
+            annual_trade_counts={},
+        )
+
+    monkeypatch.setattr(
+        manage_module.strategy,
+        "evaluate_combined_strategy",
+        fake_evaluate,
+    )
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd(
+        "start_simulate dollar_volume>100 ema_sma_cross ema_sma_cross 0.5 0.2"
+    )
+    assert stop_loss_record["value"] == 0.5
+    assert take_profit_record["value"] == 0.2
+
+
 def test_start_simulate_accepts_cash_and_withdraw(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1822,6 +1898,7 @@ def test_start_simulate_accepts_cash_and_withdraw(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -1876,6 +1953,7 @@ def test_start_simulate_accepts_strategy_set_with_commas(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **_: object,
     ) -> StrategyMetrics:
@@ -1977,6 +2055,7 @@ def test_start_simulate_accepts_windowed_strategy_names(monkeypatch: pytest.Monk
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
         **kwargs: object,
     ) -> StrategyMetrics:
@@ -2360,6 +2439,51 @@ def test_complex_simulation_strategy_id_resolution(
     assert "[Total] Trades: 0" in output_text
     assert "[A] Trades: 0" in output_text
     assert "[B] Trades: 0" in output_text
+
+
+def test_complex_simulation_accepts_take_profit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The complex command should forward take-profit values to the strategy layer."""
+
+    import stock_indicator.manage as manage_module
+
+    mapping = {"alpha": ("ema_sma_cross", "ema_sma_cross")}
+    monkeypatch.setattr(manage_module, "load_strategy_set_mapping", lambda: mapping)
+    monkeypatch.setattr(manage_module, "determine_start_date", lambda directory: "2005-01-01")
+    monkeypatch.setattr(manage_module, "STOCK_DATA_DIRECTORY", tmp_path)
+    monkeypatch.setattr(manage_module, "DATA_DIRECTORY", tmp_path)
+
+    recorded_sets: dict[str, manage_module.strategy.ComplexStrategySetDefinition] = {}
+
+    def fake_run_complex_simulation(
+        data_directory: Path,
+        set_definitions: dict[str, manage_module.strategy.ComplexStrategySetDefinition],
+        **_: object,
+    ) -> manage_module.strategy.ComplexSimulationMetrics:
+        recorded_sets.update(set_definitions)
+        empty_metrics = _create_empty_metrics()
+        return manage_module.strategy.ComplexSimulationMetrics(
+            overall_metrics=empty_metrics,
+            metrics_by_set={"A": empty_metrics, "B": empty_metrics},
+        )
+
+    monkeypatch.setattr(
+        manage_module.strategy,
+        "run_complex_simulation",
+        fake_run_complex_simulation,
+    )
+
+    shell = manage_module.StockShell(stdout=io.StringIO())
+    shell.onecmd(
+        "complex_simulation 3 dollar_volume>1 strategy=alpha 0.25 0.1 -- "
+        "dollar_volume>2 ema_sma_cross ema_sma_cross 0.3 0.2 False"
+    )
+
+    set_a = recorded_sets["A"]
+    set_b = recorded_sets["B"]
+    assert set_a.stop_loss_percentage == 0.25
+    assert set_a.take_profit_percentage == 0.1
+    assert set_b.stop_loss_percentage == 0.3
+    assert set_b.take_profit_percentage == 0.2
 
 
 def test_complex_simulation_half_cap_for_set_b_rounds_up(

--- a/tests/test_start_simulate_start_date.py
+++ b/tests/test_start_simulate_start_date.py
@@ -35,6 +35,7 @@ def test_start_simulate_accepts_start_date(monkeypatch: pytest.MonkeyPatch, tmp_
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
     ) -> StrategyMetrics:
         recorded_arguments["start_date"] = start_date

--- a/tests/test_start_simulate_symbol_mapping.py
+++ b/tests/test_start_simulate_symbol_mapping.py
@@ -36,6 +36,7 @@ def test_start_simulate_filters_pre_2014_googl(
         starting_cash: float = 3000.0,
         withdraw_amount: float = 0.0,
         stop_loss_percentage: float = 1.0,
+        take_profit_percentage: float = 0.0,
         start_date: pandas.Timestamp | None = None,
     ) -> StrategyMetrics:
         trade_details_by_year = {


### PR DESCRIPTION
## Summary
- add optional take-profit percentages to complex strategy definitions and evaluation helpers
- update the CLI simulators to parse take-profit arguments and document the new option
- extend the trade simulator with take-profit handling and refresh related tests

## Testing
- PYTHONPATH=src pytest tests/test_simulator.py tests/test_manage.py tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_b_68f1870f2db8832bad8cf4e6405fcde8