### PR TITLE
Compute previous SMA angle in filter debug values

### DIFF
--- a/src/stock_indicator/daily_job.py
+++ b/src/stock_indicator/daily_job.py
@@ -332,6 +332,7 @@ def filter_debug_values(
         LOGGER.warning("Local CSV not found for %s: %s", symbol_name, csv_file_path)
         return {
             "sma_angle": None,
+            "sma_angle_previous": None,
             "near_price_volume_ratio": None,
             "near_price_volume_ratio_previous": None,
             "above_price_volume_ratio": None,
@@ -344,6 +345,7 @@ def filter_debug_values(
     if price_history_frame.empty:
         return {
             "sma_angle": None,
+            "sma_angle_previous": None,
             "near_price_volume_ratio": None,
             "near_price_volume_ratio_previous": None,
             "above_price_volume_ratio": None,
@@ -362,6 +364,7 @@ def filter_debug_values(
         if len(candidate_index) == 0:
             return {
                 "sma_angle": None,
+                "sma_angle_previous": None,
                 "near_price_volume_ratio": None,
                 "near_price_volume_ratio_previous": None,
                 "above_price_volume_ratio": None,
@@ -377,6 +380,7 @@ def filter_debug_values(
     if selected_position_candidates.size == 0:
         return {
             "sma_angle": None,
+            "sma_angle_previous": None,
             "near_price_volume_ratio": None,
             "near_price_volume_ratio_previous": None,
             "above_price_volume_ratio": None,
@@ -417,6 +421,13 @@ def filter_debug_values(
         strategy.rename_signal_columns(
             buy_price_history_frame, buy_base_name, buy_strategy_name
         )
+        if (
+            "sma_angle" in buy_price_history_frame.columns
+            and "sma_angle_previous" not in buy_price_history_frame.columns
+        ):
+            buy_price_history_frame["sma_angle_previous"] = buy_price_history_frame[
+                "sma_angle"
+            ].shift(1)
 
     (
         sell_base_name,
@@ -440,10 +451,18 @@ def filter_debug_values(
         strategy.rename_signal_columns(
             sell_price_history_frame, sell_base_name, sell_strategy_name
         )
+        if (
+            "sma_angle" in sell_price_history_frame.columns
+            and "sma_angle_previous" not in sell_price_history_frame.columns
+        ):
+            sell_price_history_frame["sma_angle_previous"] = (
+                sell_price_history_frame["sma_angle"].shift(1)
+            )
 
     # TODO: review
     debug_column_names = [
         "sma_angle",
+        "sma_angle_previous",
         "near_price_volume_ratio",
         "near_price_volume_ratio_previous",
         "above_price_volume_ratio",
@@ -523,6 +542,7 @@ def filter_debug_values(
         if len(candidate_index) == 0:
             return {
                 "sma_angle": None,
+                "sma_angle_previous": None,
                 "near_price_volume_ratio": None,
                 "near_price_volume_ratio_previous": None,
                 "above_price_volume_ratio": None,
@@ -541,15 +561,29 @@ def filter_debug_values(
     exit_value = False
     if selected_timestamp in combined_exit_series.index:
         exit_value = bool(combined_exit_series.loc[selected_timestamp])
+    def normalize_debug_value(value: Any) -> Any:
+        if value is None:
+            return None
+        if pandas.isna(value):
+            return None
+        return value
+
     return {
-        "sma_angle": row.get("sma_angle"),
-        "near_price_volume_ratio": row.get("near_price_volume_ratio"),
-        "near_price_volume_ratio_previous": row.get(
-            "near_price_volume_ratio_previous"
+        "sma_angle": normalize_debug_value(row.get("sma_angle")),
+        "sma_angle_previous": normalize_debug_value(
+            row.get("sma_angle_previous")
         ),
-        "above_price_volume_ratio": row.get("above_price_volume_ratio"),
-        "above_price_volume_ratio_previous": row.get(
-            "above_price_volume_ratio_previous"
+        "near_price_volume_ratio": normalize_debug_value(
+            row.get("near_price_volume_ratio")
+        ),
+        "near_price_volume_ratio_previous": normalize_debug_value(
+            row.get("near_price_volume_ratio_previous")
+        ),
+        "above_price_volume_ratio": normalize_debug_value(
+            row.get("above_price_volume_ratio")
+        ),
+        "above_price_volume_ratio_previous": normalize_debug_value(
+            row.get("above_price_volume_ratio_previous")
         ),
         "entry": entry_value,
         "exit": exit_value,

--- a/tests/test_daily_job_signals.py
+++ b/tests/test_daily_job_signals.py
@@ -162,6 +162,7 @@ def test_filter_debug_values_uses_latest_available_row(
     )
 
     assert debug_values["sma_angle"] == pytest.approx(1.0)
+    assert debug_values["sma_angle_previous"] is None
     assert debug_values["near_price_volume_ratio"] == pytest.approx(0.11)
     assert debug_values["near_price_volume_ratio_previous"] is None
     assert debug_values["above_price_volume_ratio"] == pytest.approx(0.33)
@@ -242,6 +243,7 @@ def test_filter_debug_values_reports_raw_entry_signals(
 
     assert debug_values["entry"] is True
     assert debug_values["exit"] is False
+    assert debug_values["sma_angle_previous"] == pytest.approx(2.0)
     assert debug_values["near_price_volume_ratio_previous"] is None
     assert debug_values["above_price_volume_ratio_previous"] is None
 
@@ -318,5 +320,6 @@ def test_filter_debug_values_includes_shifted_entry_signals(
     assert debug_values["entry"] is True
     assert debug_values["exit"] is False
     assert debug_values["sma_angle"] == pytest.approx(4.0)
+    assert debug_values["sma_angle_previous"] == pytest.approx(3.0)
     assert debug_values["near_price_volume_ratio"] == pytest.approx(0.35)
     assert debug_values["above_price_volume_ratio"] == pytest.approx(0.65)

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -526,6 +526,7 @@ def test_filter_debug_values_prints_table(
         recorded_arguments["sell"] = sell_name
         return {
             "sma_angle": 1.0,
+            "sma_angle_previous": None,
             "near_price_volume_ratio": 0.2,
             "above_price_volume_ratio": 0.3,
             "entry": True,
@@ -555,6 +556,7 @@ def test_filter_debug_values_prints_table(
             {
                 "date": "2024-01-10",
                 "sma_angle": 1.0,
+                "sma_angle_previous": None,
                 "near_price_volume_ratio": 0.2,
                 "above_price_volume_ratio": 0.3,
                 "entry": True,
@@ -586,6 +588,7 @@ def test_filter_debug_values_with_strategy_id(
         recorded_arguments["sell"] = sell_name
         return {
             "sma_angle": 1.0,
+            "sma_angle_previous": None,
             "near_price_volume_ratio": 0.2,
             "above_price_volume_ratio": 0.3,
             "entry": True,
@@ -620,6 +623,7 @@ def test_filter_debug_values_with_strategy_id(
             {
                 "date": "2024-01-10",
                 "sma_angle": 1.0,
+                "sma_angle_previous": None,
                 "near_price_volume_ratio": 0.2,
                 "above_price_volume_ratio": 0.3,
                 "entry": True,
@@ -652,6 +656,7 @@ def test_filter_debug_values_strategy_id_with_filter_token(
         recorded_arguments["sell"] = sell_name
         return {
             "sma_angle": 1.0,
+            "sma_angle_previous": None,
             "near_price_volume_ratio": 0.2,
             "above_price_volume_ratio": 0.3,
             "entry": True,
@@ -688,6 +693,7 @@ def test_filter_debug_values_strategy_id_with_filter_token(
             {
                 "date": "2024-01-10",
                 "sma_angle": 1.0,
+                "sma_angle_previous": None,
                 "near_price_volume_ratio": 0.2,
                 "above_price_volume_ratio": 0.3,
                 "entry": True,


### PR DESCRIPTION
## Summary
- compute and expose the previous-day SMA angle when building filter debug values, normalizing missing data to None for readability
- update filter debug value tests to assert the prior SMA angle is surfaced when history exists

## Testing
- pytest tests/test_daily_job_signals.py::test_filter_debug_values_uses_latest_available_row tests/test_daily_job_signals.py::test_filter_debug_values_reports_raw_entry_signals tests/test_daily_job_signals.py::test_filter_debug_values_includes_shifted_entry_signals tests/test_manage.py::test_filter_debug_values_prints_table tests/test_manage.py::test_filter_debug_values_with_strategy_id tests/test_manage.py::test_filter_debug_values_strategy_id_with_filter_token


------
https://chatgpt.com/codex/tasks/task_b_68f32f01bdb4832b882b574ffede0404